### PR TITLE
feat: improve execution timeout configuration with validation

### DIFF
--- a/src/execution/ExecutionLimits.ts
+++ b/src/execution/ExecutionLimits.ts
@@ -20,7 +20,7 @@ export interface ExecutionLimitsConfig {
   /** Maximum output size in bytes (default: 1MB) */
   maxOutputSizeBytes: number
 
-  /** Maximum execution time in milliseconds (default: 30000) */
+  /** Maximum execution time in milliseconds (default: 90000) */
   maxExecutionTimeMs: number
 
   /** Enable resource monitoring (default: true) */
@@ -51,7 +51,7 @@ export const DEFAULT_EXECUTION_LIMITS: ExecutionLimitsConfig = {
   maxConcurrentExecutions: 5,
   maxMemoryUsageMB: 100,
   maxOutputSizeBytes: 1024 * 1024, // 1MB
-  maxExecutionTimeMs: 30000, // 30 seconds
+  maxExecutionTimeMs: 90000, // 90 seconds
   enableResourceMonitoring: true,
 }
 

--- a/src/server/McpServer.ts
+++ b/src/server/McpServer.ts
@@ -78,7 +78,7 @@ export class McpServer {
     // Create ExecutionConfig with the CLI command from server config
     const executionConfig = createExecutionConfig(config.cliCommand, {
       outputSizeThreshold: config.maxOutputSize || 1024 * 1024, // Use maxOutputSize from config
-      executionTimeout: 30000, // 30 seconds
+      executionTimeout: config.executionTimeoutMs, // Use timeout from config (env var or 90s default)
     })
 
     // Create logger with log level from config

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -45,4 +45,11 @@ export interface ServerConfigInterface {
    * Controls verbosity of server logging output.
    */
   logLevel: 'debug' | 'info' | 'warn' | 'error'
+
+  /**
+   * Maximum execution timeout in milliseconds for agent execution.
+   * Configurable via EXECUTION_TIMEOUT_MS environment variable.
+   * Default: 90000ms (90 seconds), Range: 1000ms - 240000ms (4 minutes)
+   */
+  executionTimeoutMs: number
 }


### PR DESCRIPTION
- Add configurable execution timeout via EXECUTION_TIMEOUT_MS environment variable
- Implement timeout validation with range checks (1s - 4min, default 90s)
- Update ServerConfig to include executionTimeoutMs property
- Extend ServerConfig tests with comprehensive timeout validation
- Increase default execution timeout from 30s to 90s for better stability
- Integrate timeout configuration throughout execution pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)