### PR TITLE
fix: adjust timeout values for reliable agent operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,14 @@ npx -y https://github.com/shinpr/sub-agents-mcp
 | `AGENTS_DIR` | Directory containing agent definition files | ✓ | - |
 | `CLI_COMMAND` | CLI command to execute (`cursor-agent` or `claude`) | ✓ | - |
 | `CLI_API_KEY` | API key for cursor-agent (Anthropic or OpenAI API key) | ✓ (for cursor-agent) | - |
-| `EXECUTION_TIMEOUT_MS` | Maximum execution time for agent operations in milliseconds | | 180000 (3 minutes) |
+| `EXECUTION_TIMEOUT_MS` | Maximum execution time for agent operations in milliseconds (MCP->AI) | | 300000 (5 minutes) |
 
-**Note:** For complex agents that require longer processing times (e.g., document reviewers, code analyzers), you can increase the timeout by setting `EXECUTION_TIMEOUT_MS` to a higher value, up to 300000 (5 minutes).
+**Note:** For complex agents that require longer processing times (e.g., document reviewers, code analyzers), you can increase the timeout by setting `EXECUTION_TIMEOUT_MS` to a higher value, up to 600000 (10 minutes).
+
+**Timeout Hierarchy:**
+- **AI->MCP timeout**: 11 minutes (660 seconds) - Maximum time AI waits for MCP server response
+- **MCP->AI timeout**: 5-10 minutes (configurable via `EXECUTION_TIMEOUT_MS`) - Maximum time MCP waits for AI response  
+- **Idle timeout**: 2 minutes (120 seconds) - Time without data before terminating stuck processes
 
 ### Agent Definition Format
 

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -100,12 +100,12 @@ export class ServerConfig implements ServerConfigInterface {
    * Validates execution timeout value from environment variable.
    *
    * @param executionTimeoutEnv - Raw EXECUTION_TIMEOUT_MS environment variable value
-   * @returns Valid execution timeout in milliseconds (180000ms default)
+   * @returns Valid execution timeout in milliseconds (300000ms default)
    */
   private validateExecutionTimeout(executionTimeoutEnv: string | undefined): number {
-    const DEFAULT_TIMEOUT = 180000 // 3 minutes default
+    const DEFAULT_TIMEOUT = 300000 // 5 minutes default
     const MIN_TIMEOUT = 1000 // 1 second minimum
-    const MAX_TIMEOUT = 300000 // 5 minutes maximum
+    const MAX_TIMEOUT = 600000 // 10 minutes maximum
 
     if (!executionTimeoutEnv) {
       return DEFAULT_TIMEOUT

--- a/src/config/__tests__/ServerConfig.test.ts
+++ b/src/config/__tests__/ServerConfig.test.ts
@@ -50,7 +50,7 @@ describe('ServerConfig', () => {
     expect(config.serverName).toBe('sub-agents-mcp-server')
     expect(config.agentsDir).toBe('./agents')
     expect(config.cliCommand).toBe('claude-code')
-    expect(config.executionTimeoutMs).toBe(180000)
+    expect(config.executionTimeoutMs).toBe(300000)
   })
 
   it('should validate required environment variables', () => {
@@ -83,7 +83,7 @@ describe('ServerConfig', () => {
 
       const config = new ServerConfig()
 
-      expect(config.executionTimeoutMs).toBe(180000) // 3 minutes default
+      expect(config.executionTimeoutMs).toBe(300000) // 5 minutes default
     })
 
     it('should use valid timeout from environment variable', () => {
@@ -100,14 +100,14 @@ describe('ServerConfig', () => {
       vi.stubEnv('AGENTS_DIR', testAgentsDir)
 
       // Test invalid values
-      const invalidValues = ['invalid', '500', '400000', '-1000'] // too low, too high, negative
+      const invalidValues = ['invalid', '500', '700000', '-1000'] // too low, too high, negative
 
       for (const invalidValue of invalidValues) {
         vi.stubEnv('EXECUTION_TIMEOUT_MS', invalidValue)
 
         const config = new ServerConfig()
 
-        expect(config.executionTimeoutMs).toBe(180000) // Should use default
+        expect(config.executionTimeoutMs).toBe(300000) // Should use default
         expect(consoleSpy).toHaveBeenCalledWith(
           expect.stringContaining(`Invalid EXECUTION_TIMEOUT_MS value: ${invalidValue}`)
         )
@@ -120,7 +120,7 @@ describe('ServerConfig', () => {
       const validValues = [
         { input: '1000', expected: 1000 }, // minimum
         { input: '60000', expected: 60000 }, // 1 minute
-        { input: '300000', expected: 300000 }, // maximum (5 minutes)
+        { input: '600000', expected: 600000 }, // maximum (10 minutes)
       ]
       vi.stubEnv('AGENTS_DIR', testAgentsDir)
 
@@ -138,7 +138,7 @@ describe('ServerConfig', () => {
     vi.stubEnv('SERVER_NAME', 'test-server')
     vi.stubEnv('AGENTS_DIR', testAgentsDir)
     vi.stubEnv('CLI_COMMAND', 'test-cli')
-    vi.stubEnv('EXECUTION_TIMEOUT_MS', '180000')
+    vi.stubEnv('EXECUTION_TIMEOUT_MS', '300000')
 
     const config = new ServerConfig()
     const configObject = config.toObject()
@@ -151,7 +151,7 @@ describe('ServerConfig', () => {
       maxOutputSize: 1048576,
       enableCache: true,
       logLevel: 'info',
-      executionTimeoutMs: 180000,
+      executionTimeoutMs: 300000,
     })
 
     // Verify it's readonly (modification should throw error)

--- a/src/execution/AgentExecutor.ts
+++ b/src/execution/AgentExecutor.ts
@@ -369,7 +369,7 @@ export class AgentExecutor {
       let assistantResponse: string | null = null
       let idleTimer: NodeJS.Timeout | null = null
       let assistantStarted = false
-      const IDLE_TIMEOUT = 60000 // 60 seconds of no data AFTER assistant starts responding
+      const IDLE_TIMEOUT = 120000 // 2 minutes of no data AFTER assistant starts responding
 
       // Close stdin immediately as we're not sending any input
       childProcess.stdin?.end()

--- a/src/execution/McpRequestTimeout.ts
+++ b/src/execution/McpRequestTimeout.ts
@@ -40,8 +40,8 @@ export interface McpTimeoutConfig {
  * Based on MCP best practices and LLM operation characteristics
  */
 export const DEFAULT_MCP_TIMEOUT_CONFIG: McpTimeoutConfig = {
-  defaultTimeoutMs: 120000, // 2 minutes - considering LLM processing time
-  maxTimeoutMs: 300000, // 5 minutes - absolute maximum
+  defaultTimeoutMs: 360000, // 6 minutes - considering complex agent operations
+  maxTimeoutMs: 660000, // 11 minutes - absolute maximum for AI->MCP
   progressResetEnabled: true,
   warningThresholdMs: 60000, // 1 minute - send progress notification
   enableDebugLogging: false,

--- a/src/execution/__tests__/McpRequestTimeout.test.ts
+++ b/src/execution/__tests__/McpRequestTimeout.test.ts
@@ -69,7 +69,7 @@ describe('McpRequestTimeout', () => {
 
       timeout.startTimeout('test-req-3', onTimeout, onProgress)
 
-      // Fast-forward to default timeout (2 minutes by default)
+      // Fast-forward to default timeout (6 minutes by default)
       vi.advanceTimersByTime(DEFAULT_MCP_TIMEOUT_CONFIG.defaultTimeoutMs)
 
       expect(onTimeout).toHaveBeenCalledTimes(1)
@@ -96,8 +96,8 @@ describe('McpRequestTimeout', () => {
       vi.advanceTimersByTime(60000) // 3 minutes total
       timeout.reportProgress('test-req-4', 'Almost done', 75)
 
-      // Fast-forward to max timeout (5 minutes by default)
-      vi.advanceTimersByTime(120000) // 5 minutes total
+      // Fast-forward to max timeout (11 minutes by default)
+      vi.advanceTimersByTime(480000) // Advance 8 more minutes (total 11 minutes)
 
       expect(onTimeout).toHaveBeenCalledTimes(1)
     })
@@ -123,22 +123,22 @@ describe('McpRequestTimeout', () => {
 
       timeout.startTimeout('test-req-6', onTimeout)
 
-      // Advance to 90 seconds (less than default timeout of 2 minutes)
-      vi.advanceTimersByTime(90000)
+      // Advance to 300 seconds (less than default timeout of 6 minutes = 360 seconds)
+      vi.advanceTimersByTime(300000)
 
       // Report progress - should reset timeout
       timeout.reportProgress('test-req-6', 'Still processing')
 
-      // Advance another 90 seconds (total 180 seconds)
-      vi.advanceTimersByTime(90000)
+      // Advance another 300 seconds (total 600 seconds = 10 minutes)
+      vi.advanceTimersByTime(300000)
 
       // Should not have timed out yet because of reset
       expect(onTimeout).not.toHaveBeenCalled()
 
-      // Advance to new timeout (30 more seconds to reach 210 seconds total)
-      vi.advanceTimersByTime(30000) // Total 210 seconds
+      // Advance to new timeout (60 more seconds to reach 11 minutes total)
+      vi.advanceTimersByTime(60000) // Total 11 minutes
 
-      // Now it should timeout (90s + 120s after reset = 210s total)
+      // Now it should timeout
       expect(onTimeout).toHaveBeenCalledTimes(1)
     })
 


### PR DESCRIPTION
- Increase base timeout from 2 to 6 minutes for complex agent tasks
- Extend max timeout from 5 to 11 minutes for extensive operations
- Fix test assertions to match new timeout configurations
- Ensure timeout hierarchy consistency across all components

These changes prevent premature timeouts during legitimate long-running agent operations while maintaining responsive timeout detection.

🤖 Generated with [Claude Code](https://claude.ai/code)