### PR TITLE
fix: resolve cursor-agent session disconnect and process hang issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npx -y https://github.com/shinpr/sub-agents-mcp
 |----------|-------------|----------|---------|
 | `AGENTS_DIR` | Absolute path to directory containing agent definition files | ✓ | - |
 | `AGENT_TYPE` | Type of agent to use (`cursor` or `claude`) | | `cursor` |
-| `CLI_API_KEY` | API key for cursor-agent (Anthropic or OpenAI API key) | ✓ (for cursor) | - |
+| `CLI_API_KEY` | Cursor API key for cursor-agent authentication. Optional if cursor-agent is logged in via `cursor-agent login`. May affect session behavior when provided. | | - |
 | `EXECUTION_TIMEOUT_MS` | Maximum execution time for agent operations in milliseconds (MCP->AI) | | 300000 (5 minutes) |
 
 **Note:** For complex agents that require longer processing times (e.g., document reviewers, code analyzers), you can increase the timeout by setting `EXECUTION_TIMEOUT_MS` to a higher value, up to 600000 (10 minutes).
@@ -181,7 +181,7 @@ Executes another agent with specified parameters.
    - For `cursor`: Ensure `cursor-agent` CLI is installed
    - For `claude`: Ensure Claude Code CLI is installed
 3. Check environment variables are properly set
-4. For cursor agent type, ensure `CLI_API_KEY` is set with valid API key
+4. For cursor agent type, ensure either cursor-agent is logged in (`cursor-agent login`) or `CLI_API_KEY` is set with valid API key
 
 ## How It Works
 
@@ -211,7 +211,7 @@ Add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project-specific):
       "env": {
         "AGENTS_DIR": "/Users/username/projects/my-app/agents",
         "AGENT_TYPE": "cursor",
-        "CLI_API_KEY": "your-api-key"
+        "CLI_API_KEY": "your-api-key"  // Optional: remove if using cursor-agent login
       }
     }
   }
@@ -251,7 +251,7 @@ You can use different agent directories by updating the `AGENTS_DIR` in your IDE
       "env": {
         "AGENTS_DIR": "/Users/username/projects/my-app/dev-agents",
         "AGENT_TYPE": "cursor",
-        "CLI_API_KEY": "your-api-key"
+        "CLI_API_KEY": "your-api-key"  // Optional: remove if using cursor-agent login
       }
     },
     "sub-agents-prod": {
@@ -260,7 +260,7 @@ You can use different agent directories by updating the `AGENTS_DIR` in your IDE
       "env": {
         "AGENTS_DIR": "/Users/username/projects/my-app/prod-agents",
         "AGENT_TYPE": "cursor",
-        "CLI_API_KEY": "your-api-key"
+        "CLI_API_KEY": "your-api-key"  // Optional: remove if using cursor-agent login
       }
     }
   }

--- a/src/execution/AgentExecutor.ts
+++ b/src/execution/AgentExecutor.ts
@@ -236,7 +236,7 @@ export class AgentExecutor {
       // Spawn process
       const childProcess: ChildProcess = spawn(command, args, {
         cwd: params.cwd || process.cwd(),
-        stdio: ['pipe', 'pipe', 'pipe'],
+        stdio: ['ignore', 'pipe', 'pipe'], // stdin set to 'ignore' as cursor-agent receives prompt via args
         shell: false,
         env: process.env,
       })
@@ -247,7 +247,7 @@ export class AgentExecutor {
       let stderr = ''
       let stdoutBuffer = ''
 
-      childProcess.stdin?.end()
+      // No need to handle stdin as it's set to 'ignore'
       const executionTimeout = setTimeout(() => {
         this.logger.warn('Execution timeout reached', {
           timeout: this.config.executionTimeout,


### PR DESCRIPTION
- Set stdin to 'ignore' in spawn to prevent process hang issues
- Remove stdin.end() call that was causing session disconnection
- Update README to clarify CLI_API_KEY as optional Cursor authentication key
- Fix documentation describing API key as Anthropic/OpenAI key (incorrect)
- Add guidance for choosing between cursor-agent login vs API key authentication

This resolves timeout issues and zombie processes while maintaining compatibility with both session-based and API key-based authentication methods.

🤖 Generated with [Claude Code](https://claude.ai/code)