### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Let your AI assistant (Cursor, Claude) use specialized sub-agents for specific tasks. For example, create a "test-writer" agent that writes tests, or a "code-reviewer" agent that reviews your code.
 
+<a href="https://glama.ai/mcp/servers/@shinpr/sub-agents-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@shinpr/sub-agents-mcp/badge" alt="Task Agents MCP server" />
+</a>
+
 ## Why sub-agents-mcp?
 
 While Claude Code has excellent built-in sub-agent functionality, it's exclusive to Claude Code. This MCP server brings that same powerful sub-agent pattern to **ANY LLM tool that supports MCP** - including Cursor, Windsurf, and others.


### PR DESCRIPTION
This PR adds a badge for the [Task Agents](https://glama.ai/mcp/servers/@shinpr/sub-agents-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@shinpr/sub-agents-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@shinpr/sub-agents-mcp/badge" alt="Task Agents MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.