### PR TITLE
fix: redirect all logging to stderr for MCP protocol compliance

### DIFF
--- a/src/__tests__/performance/startup.test.ts
+++ b/src/__tests__/performance/startup.test.ts
@@ -59,7 +59,8 @@ describe('Startup Performance Tests', () => {
           reject(new Error('Startup timeout exceeded 5 seconds'))
         }, 5000)
 
-        serverProcess.stdout?.on('data', (data) => {
+        // MCP server logs to stderr (MCP protocol compliance)
+        serverProcess.stderr?.on('data', (data) => {
           const output = data.toString()
           if (
             output.includes('MCP server started') ||
@@ -72,12 +73,12 @@ describe('Startup Performance Tests', () => {
           }
         })
 
-        serverProcess.stderr?.on('data', (data) => {
-          // Capture stderr for debugging failed tests
-          const stderrOutput = data.toString()
-          if (stderrOutput.includes('error') || stderrOutput.includes('Error')) {
-            clearTimeout(timeout)
-            reject(new Error(`Server startup error: ${stderrOutput}`))
+        serverProcess.stdout?.on('data', (data) => {
+          // stdout should only contain JSON-RPC messages in MCP protocol
+          // Log for debugging if anything unexpected appears
+          const stdoutData = data.toString()
+          if (stdoutData.trim()) {
+            console.warn('Unexpected stdout output:', stdoutData)
           }
         })
 
@@ -148,7 +149,8 @@ describe('Startup Performance Tests', () => {
             reject(new Error('Stress test startup timeout exceeded 5 seconds'))
           }, 5000)
 
-          serverProcess.stdout?.on('data', (data) => {
+          // MCP server logs to stderr (MCP protocol compliance)
+          serverProcess.stderr?.on('data', (data) => {
             const output = data.toString()
             if (
               output.includes('MCP server started') ||
@@ -161,12 +163,12 @@ describe('Startup Performance Tests', () => {
             }
           })
 
-          serverProcess.stderr?.on('data', (data) => {
-            // Capture stderr for debugging
-            const stderrOutput = data.toString()
-            if (stderrOutput.includes('error') || stderrOutput.includes('Error')) {
-              clearTimeout(timeout)
-              reject(new Error(`Stress test error: ${stderrOutput}`))
+          serverProcess.stdout?.on('data', (data) => {
+            // stdout should only contain JSON-RPC messages in MCP protocol
+            // Log for debugging if anything unexpected appears
+            const stdoutData = data.toString()
+            if (stdoutData.trim()) {
+              console.warn('Unexpected stdout output:', stdoutData)
             }
           })
 

--- a/src/server/McpServer.ts
+++ b/src/server/McpServer.ts
@@ -147,7 +147,7 @@ export class McpServer {
         service: 'mcp-server',
         ...metadata,
       }
-      console.log(JSON.stringify(logEntry))
+      console.error(JSON.stringify(logEntry))
     }
   }
 

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -139,9 +139,9 @@ export class Logger {
     const formattedMessage = `[${timestamp}] ${level.toUpperCase()}: ${message}`
 
     if (context && Object.keys(context).length > 0) {
-      console.log(formattedMessage, context)
+      console.error(formattedMessage, context)
     } else {
-      console.log(formattedMessage)
+      console.error(formattedMessage)
     }
 
     // Optional file output in JSON format

--- a/src/utils/__tests__/Logger.test.ts
+++ b/src/utils/__tests__/Logger.test.ts
@@ -6,7 +6,7 @@ describe('Logger', () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     logger = new Logger('info')
   })
 
@@ -19,7 +19,7 @@ describe('Logger', () => {
     it('should filter logs based on constructor level', () => {
       // Arrange
       const warnLogger = new Logger('warn')
-      const warnSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       // Act
       warnLogger.debug('Debug message')
@@ -38,7 +38,7 @@ describe('Logger', () => {
     it('should log all levels when created with debug level', () => {
       // Arrange
       const debugLogger = new Logger('debug')
-      const debugSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const debugSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       // Act
       debugLogger.debug('Debug message')
@@ -59,7 +59,7 @@ describe('Logger', () => {
     it('should only log errors when created with error level', () => {
       // Arrange
       const errorLogger = new Logger('error')
-      const errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       // Act
       errorLogger.debug('Debug message')
@@ -178,7 +178,7 @@ describe('Logger', () => {
     it('should provide debug logging method', () => {
       // Arrange
       const debugLogger = new Logger('debug')
-      const debugSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const debugSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       // Act
       debugLogger.debug('Debug information', { component: 'test' })
@@ -217,7 +217,7 @@ describe('Logger', () => {
     it('should use default info level when no level provided', () => {
       // Arrange
       const defaultLogger = new Logger()
-      const infoSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const infoSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       // Act - info should log, debug should not
       defaultLogger.debug('Debug msg')
@@ -234,7 +234,7 @@ describe('Logger', () => {
       // Arrange
       const debugLogger = new Logger('debug')
       const errorLogger = new Logger('error')
-      const debugSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const debugSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       // Act
       debugLogger.debug('Debug from debug logger')


### PR DESCRIPTION
## Summary
Fixes #18 - MCP server outputting non-JSON-RPC formatted logs to stdout

This PR implements proper stdout/stderr separation to comply with the MCP protocol requirement that **only JSON-RPC 2.0 messages should be sent to stdout**.

## Changes
- **Logger.ts**: Changed `console.log()` to `console.error()` for all log output
- **McpServer.ts**: Redirected JSON log entries to stderr instead of stdout
- **Logger.test.ts**: Updated test spies to expect stderr output
- **startup.test.ts**: Updated tests to read server startup logs from stderr

## MCP Protocol Compliance
After this change:
- ✅ **stdout**: JSON-RPC 2.0 messages only
- ✅ **stderr**: All logging output

## Issues Resolved
This resolves the following errors reported in Issue #18:
- ❌ JSON-RPC validation errors ("Invalid literal value, expected '2.0'")
- ❌ MCP client parsing failures
- ❌ Timeout errors due to protocol violations

## Test Results
All tests passing:
```
Test Files  16 passed (16)
      Tests  179 passed (179)
```

All quality checks successful:
- ✅ Biome check
- ✅ Lint
- ✅ Format
- ✅ TypeScript build
- ✅ No circular dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)