### PR TITLE
docs: fix SESSION_RETENTION_DAYS default value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Add these environment variables to your MCP configuration:
         "AGENT_TYPE": "cursor",
         "SESSION_ENABLED": "true",
         "SESSION_DIR": "/absolute/path/to/session-storage",
-        "SESSION_RETENTION_DAYS": "7"
+        "SESSION_RETENTION_DAYS": "1"
       }
     }
   }
@@ -276,7 +276,7 @@ Add these environment variables to your MCP configuration:
 
 - `SESSION_ENABLED` - Set to `"true"` to enable session management (default: `false`)
 - `SESSION_DIR` - Where to store session files (default: `.mcp-sessions` in the current working directory)
-- `SESSION_RETENTION_DAYS` - How long to keep session history in days (default: 7)
+- `SESSION_RETENTION_DAYS` - How long to keep session files based on last modification time in days (default: 1)
 
 **Security consideration:** Session files contain execution history and may include sensitive information. Use absolute paths for `SESSION_DIR`.
 


### PR DESCRIPTION
## Summary

Fixes incorrect default value for `SESSION_RETENTION_DAYS` in README documentation.

## Issue

The README stated the default retention period as 7 days, but the actual implementation in `ServerConfig.ts` uses 1 day as the default.

## Changes

- **Configuration example**: Changed `"SESSION_RETENTION_DAYS": "7"` to `"1"`
- **Default value description**: Changed `(default: 7)` to `(default: 1)`
- **Clarification**: Added "based on last modification time" to explain mtime-based cleanup behavior

## Files Changed

- `README.md` (2 lines)

## Verification

The actual default value in the code:
```typescript
// src/config/ServerConfig.ts:93
this.sessionRetentionDays = Number.isNaN(parsedDays) || parsedDays <= 0 ? 1 : parsedDays
```

Documentation now matches implementation.