### PR TITLE
fix: update RunAgentInputSchema type for MCP SDK 1.24.0 compatibility

### DIFF
--- a/src/tools/RunAgentTool.ts
+++ b/src/tools/RunAgentTool.ts
@@ -57,7 +57,7 @@ interface RunAgentInputSchema {
   [x: string]: unknown
   type: 'object'
   properties: {
-    [x: string]: unknown
+    [x: string]: object
     agent: {
       type: 'string'
       description: string


### PR DESCRIPTION
## Summary
- Change `properties` index signature from `unknown` to `object` in `RunAgentInputSchema`
- This fixes type compatibility with `@modelcontextprotocol/sdk` 1.24.0

## Context
PR #32 (Dependabot) updates `@modelcontextprotocol/sdk` from 1.17.3 to 1.24.0, but the build fails due to stricter type requirements in the new version.

This PR prepares the codebase for that update. After merging this PR, please run `@dependabot rebase` on PR #32.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (249 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)