### PR TITLE
perf: fix Claude CLI 6-9x performance degradation via stream-json output

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "ai-agents",
     "claude-code",
     "cursor",
+    "gemini",
+    "codex",
     "llm",
     "cli",
-    "agent-orchestration",
-    "typescript"
+    "agent-orchestration"
   ],
   "author": "Shinsuke Kagawa",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/sub-agents-mcp",
     "source": "github"
   },
-  "version": "0.3.0",
+  "version": "0.4.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "sub-agents-mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       },
@@ -87,6 +87,7 @@
     "claude-code",
     "cursor",
     "gemini",
+    "codex",
     "llm",
     "cli",
     "agent-orchestration"

--- a/src/execution/AgentExecutor.ts
+++ b/src/execution/AgentExecutor.ts
@@ -228,10 +228,16 @@ export class AgentExecutor {
         args = ['exec', '--json', formattedPrompt]
       } else {
         // Cursor, Claude, Gemini use similar interface with -p flag
-        // Use stream-json for Gemini (each line is a complete JSON object)
-        // Use json for Cursor and Claude (single JSON response)
-        const outputFormat = this.config.agentType === 'gemini' ? 'stream-json' : 'json'
-        args = ['--output-format', outputFormat, '-p', formattedPrompt]
+        // Claude/Gemini: Use stream-json for real-time output (avoids buffering issues)
+        // Cursor: Use json (single JSON response)
+        if (this.config.agentType === 'claude') {
+          // Claude needs --verbose with stream-json for proper line-by-line flushing
+          args = ['--output-format', 'stream-json', '--verbose', '-p', formattedPrompt]
+        } else if (this.config.agentType === 'gemini') {
+          args = ['--output-format', 'stream-json', '-p', formattedPrompt]
+        } else {
+          args = ['--output-format', 'json', '-p', formattedPrompt]
+        }
 
         // Determine command based on agent type
         command =

--- a/src/tools/RunAgentTool.ts
+++ b/src/tools/RunAgentTool.ts
@@ -120,7 +120,7 @@ export class RunAgentTool {
     properties: {
       agent: {
         type: 'string',
-        description: 'Identifier of the specialized agent to delegate the task to',
+        description: 'Agent name exactly as listed in list_agents resource.',
       },
       prompt: {
         type: 'string',


### PR DESCRIPTION
## Summary
- Fix Claude CLI execution via MCP taking 6-9x longer than direct execution (36-53s → ~5s)
- Change output format from `json` to `stream-json --verbose` for line-by-line flushing
- Improve agent parameter description to guide LLM to reference list_agents first

## Root Cause
When Claude CLI runs with `--output-format json` in pipe mode (non-TTY), output is buffered until process termination. This causes StreamProcessor to wait for the buffer flush instead of detecting `type: "result"` immediately.

## Changes
- `AgentExecutor.ts`: Use `--output-format stream-json --verbose` for Claude CLI
- `RunAgentTool.ts`: Improve agent parameter description for better LLM guidance
- `server.json`: Sync version to 0.4.0, add codex tag
- `package.json`: Add gemini/codex keywords, remove typescript

## Test Plan
- [x] Manual E2E test: Claude CLI execution time ~5s (was 36-53s)
- [x] Verify `hasResult: true` in logs
- [x] All existing tests pass (257 tests)
- [x] Quality checks pass (npm run check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)