### PR TITLE
feat: track latest CLI parameters and add AGENT_PERMISSION (0.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,15 @@ Which execution engine to use:
 
 ### Optional Settings
 
+**`AGENT_PERMISSION`**
+Approval/sandbox level the sub-agent runs with. Default: `"safe-edit"`.
+
+- `"read-only"` — investigation/review only, no edits or shell writes (codex `-s read-only` / claude `--permission-mode plan` / gemini `--approval-mode plan` / cursor `--mode plan`)
+- `"safe-edit"` — auto-approve edits and suppress prompts (codex `-s workspace-write` + `approval_policy=never` / claude `--permission-mode acceptEdits` / gemini `--approval-mode auto_edit` / cursor `--trust`)
+- `"yolo"` — bypass all approvals and sandboxing. Use with care.
+
+Sub-agents have no stdin, so any approval prompt would deadlock the run. The default `safe-edit` removes prompts; the depth of sandboxing depends on the CLI — codex enforces a `workspace-write` sandbox, while claude / gemini / cursor only auto-approve and do not jail edits to the workspace. If you need strict containment, use `read-only` and run privileged steps separately.
+
 **`EXECUTION_TIMEOUT_MS`**
 How long agents can run before timing out (default: 5 minutes, max: 10 minutes)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,17 +15,17 @@
         "sub-agents-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.12",
+        "@biomejs/biome": "^2.4.14",
         "@types/node": "^25.6.0",
-        "@vitest/coverage-v8": "^4.1.4",
-        "@vitest/ui": "^4.1.4",
+        "@vitest/coverage-v8": "^4.1.5",
+        "@vitest/ui": "^4.1.5",
         "dpdm": "^4.0.1",
         "husky": "^9.1.7",
-        "lint-staged": "^16.3.2",
+        "lint-staged": "^17.0.2",
         "report-missing-dependencies": "^1.0.18",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
-        "vitest": "^4.1.4"
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=22"
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.12.tgz",
-      "integrity": "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==",
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+      "integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -108,20 +108,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.4.12",
-        "@biomejs/cli-darwin-x64": "2.4.12",
-        "@biomejs/cli-linux-arm64": "2.4.12",
-        "@biomejs/cli-linux-arm64-musl": "2.4.12",
-        "@biomejs/cli-linux-x64": "2.4.12",
-        "@biomejs/cli-linux-x64-musl": "2.4.12",
-        "@biomejs/cli-win32-arm64": "2.4.12",
-        "@biomejs/cli-win32-x64": "2.4.12"
+        "@biomejs/cli-darwin-arm64": "2.4.14",
+        "@biomejs/cli-darwin-x64": "2.4.14",
+        "@biomejs/cli-linux-arm64": "2.4.14",
+        "@biomejs/cli-linux-arm64-musl": "2.4.14",
+        "@biomejs/cli-linux-x64": "2.4.14",
+        "@biomejs/cli-linux-x64-musl": "2.4.14",
+        "@biomejs/cli-win32-arm64": "2.4.14",
+        "@biomejs/cli-win32-x64": "2.4.14"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.12.tgz",
-      "integrity": "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==",
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.14.tgz",
+      "integrity": "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==",
       "cpu": [
         "arm64"
       ],
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.12.tgz",
-      "integrity": "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==",
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.14.tgz",
+      "integrity": "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==",
       "cpu": [
         "x64"
       ],
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.12.tgz",
-      "integrity": "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==",
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.14.tgz",
+      "integrity": "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==",
       "cpu": [
         "arm64"
       ],
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.12.tgz",
-      "integrity": "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==",
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.14.tgz",
+      "integrity": "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==",
       "cpu": [
         "arm64"
       ],
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.12.tgz",
-      "integrity": "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==",
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.14.tgz",
+      "integrity": "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==",
       "cpu": [
         "x64"
       ],
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.12.tgz",
-      "integrity": "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==",
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.14.tgz",
+      "integrity": "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==",
       "cpu": [
         "x64"
       ],
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.12.tgz",
-      "integrity": "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==",
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.14.tgz",
+      "integrity": "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==",
       "cpu": [
         "arm64"
       ],
@@ -238,9 +238,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.12.tgz",
-      "integrity": "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==",
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.14.tgz",
+      "integrity": "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==",
       "cpu": [
         "x64"
       ],
@@ -255,9 +255,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -830,9 +830,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.126.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
-      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -847,9 +847,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
       "cpu": [
         "arm64"
       ],
@@ -864,9 +864,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
       "cpu": [
         "arm64"
       ],
@@ -881,9 +881,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
       "cpu": [
         "x64"
       ],
@@ -898,9 +898,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
       "cpu": [
         "x64"
       ],
@@ -915,9 +915,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
-      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
       "cpu": [
         "arm"
       ],
@@ -932,9 +932,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
       "cpu": [
         "arm64"
       ],
@@ -949,9 +949,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
       "cpu": [
         "arm64"
       ],
@@ -966,9 +966,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
       "cpu": [
         "ppc64"
       ],
@@ -983,9 +983,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
       "cpu": [
         "s390x"
       ],
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
       "cpu": [
         "x64"
       ],
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
       "cpu": [
         "x64"
       ],
@@ -1034,9 +1034,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
       "cpu": [
         "arm64"
       ],
@@ -1051,9 +1051,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
       "cpu": [
         "wasm32"
       ],
@@ -1061,8 +1061,8 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
         "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
@@ -1070,9 +1070,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
       "cpu": [
         "arm64"
       ],
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
       "cpu": [
         "x64"
       ],
@@ -1104,9 +1104,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
-      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1118,9 +1118,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1164,14 +1164,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
-      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1185,8 +1185,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.4",
-        "vitest": "4.1.4"
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1195,16 +1195,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1213,13 +1213,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1240,9 +1240,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1253,13 +1253,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1267,14 +1267,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1283,9 +1283,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1293,13 +1293,13 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.4.tgz",
-      "integrity": "sha512-EgFR7nlj5iTDYZYCvavjFokNYwr3c3ry0sFiCg+N7B233Nwp+NNx7eoF/XvMWDCKY71xXAG3kFkt97ZHBJVL8A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
+      "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "fflate": "^0.8.2",
         "flatted": "^3.4.2",
         "pathe": "^2.0.3",
@@ -1311,17 +1311,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.4"
+        "vitest": "4.1.5"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1647,23 +1647,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1982,9 +1965,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3001,45 +2984,76 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
-      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.2.tgz",
+      "integrity": "sha512-Rbr6rdmbCn1fIDHBZpn0madg0hEkdlh+QwajnL3Qq0ZUq/icAJfLGj9BVBajAXi7657ZzKQ7kobGP9S5XOHYRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
-        "listr2": "^9.0.5",
-        "picomatch": "^4.0.3",
+        "listr2": "^10.2.1",
+        "picomatch": "^4.0.4",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.0.4",
-        "yaml": "^2.8.2"
+        "tinyexec": "^1.1.2"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
       },
       "engines": {
-        "node": ">=20.17"
+        "node": ">=22.22.1"
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.8.4"
       }
     },
     "node_modules/listr2": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
-      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^5.0.0",
-        "colorette": "^2.0.20",
-        "eventemitter3": "^5.0.1",
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
         "log-update": "^6.1.0",
         "rfdc": "^1.4.1",
-        "wrap-ansi": "^9.0.0"
+        "wrap-ansi": "^10.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/log-update": {
@@ -3251,9 +3265,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -3460,9 +3474,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -3637,14 +3651,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.126.0",
-        "@rolldown/pluginutils": "1.0.0-rc.16"
+        "@oxc-project/types": "=0.128.0",
+        "@rolldown/pluginutils": "1.0.0-rc.18"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3653,21 +3667,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
       }
     },
     "node_modules/router": {
@@ -4031,9 +4045,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4194,16 +4208,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
-      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.16",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0-rc.18",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -4220,7 +4234,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -4272,19 +4286,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4312,12 +4326,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4459,11 +4473,12 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-agents-mcp",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-agents-mcp",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"
@@ -28,7 +28,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.22.2"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sub-agents-mcp",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "mcpName": "io.github.shinpr/sub-agents-mcp",
   "description": "MCP server for delegating tasks to specialized AI assistants in Cursor and other tools",
   "type": "module",
@@ -83,7 +83,7 @@
     "vitest": "^4.1.5"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.22.2"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -70,17 +70,17 @@
     "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.12",
+    "@biomejs/biome": "^2.4.14",
     "@types/node": "^25.6.0",
-    "@vitest/coverage-v8": "^4.1.4",
-    "@vitest/ui": "^4.1.4",
+    "@vitest/coverage-v8": "^4.1.5",
+    "@vitest/ui": "^4.1.5",
     "dpdm": "^4.0.1",
     "husky": "^9.1.7",
-    "lint-staged": "^16.3.2",
+    "lint-staged": "^17.0.2",
     "report-missing-dependencies": "^1.0.18",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.5"
   },
   "engines": {
     "node": ">=22"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/sub-agents-mcp",
     "source": "github"
   },
-  "version": "0.7.1",
+  "version": "0.8.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "sub-agents-mcp",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,10 +28,24 @@
         },
         {
           "name": "AGENT_TYPE",
-          "description": "Type of AI CLI to use: 'cursor', 'claude', or 'gemini'",
+          "description": "Type of AI CLI to use: 'cursor', 'claude', 'gemini', or 'codex'",
           "isRequired": true,
           "format": "string",
           "isSecret": false
+        },
+        {
+          "name": "AGENT_PERMISSION",
+          "description": "Approval/sandbox level for sub-agents: 'read-only', 'safe-edit' (default), or 'yolo'",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "CURSOR_API_KEY",
+          "description": "API key for cursor-agent authentication (used only when AGENT_TYPE=cursor; passed via env, never via CLI args)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
         },
         {
           "name": "EXECUTION_TIMEOUT_MS",

--- a/src/__tests__/integration/McpServer.integration.test.ts
+++ b/src/__tests__/integration/McpServer.integration.test.ts
@@ -20,6 +20,7 @@ describe('McpServer Integration', () => {
       agentsDir: './test-agents',
       logLevel: 'info',
       agentType: 'cursor',
+      agentPermission: 'safe-edit',
       executionTimeoutMs: 300000,
       sessionEnabled: false,
       sessionDir: '.mcp-sessions',

--- a/src/__tests__/integration/RunAgentTool.integration.test.ts
+++ b/src/__tests__/integration/RunAgentTool.integration.test.ts
@@ -23,6 +23,7 @@ describe('RunAgentTool', () => {
       serverVersion: '1.0.0',
       agentsDir: './test-agents',
       agentType: 'cursor',
+      agentPermission: 'safe-edit',
       logLevel: 'info',
       executionTimeoutMs: 300000,
       sessionEnabled: false,

--- a/src/__tests__/integration/ServerConfig.integration.test.ts
+++ b/src/__tests__/integration/ServerConfig.integration.test.ts
@@ -64,6 +64,44 @@ describe('ServerConfig', () => {
     expect(() => new ServerConfig()).toThrow(/Invalid AGENT_TYPE/)
   })
 
+  it.each([
+    'read-only',
+    'safe-edit',
+    'yolo',
+  ] as const)('should accept AGENT_PERMISSION=%s', (permission) => {
+    vi.stubEnv('AGENTS_DIR', testAgentsDir)
+    vi.stubEnv('AGENT_PERMISSION', permission)
+
+    const config = new ServerConfig()
+
+    expect(config.agentPermission).toBe(permission)
+  })
+
+  it('should default AGENT_PERMISSION to safe-edit when not set', () => {
+    vi.stubEnv('AGENTS_DIR', testAgentsDir)
+    vi.stubEnv('AGENT_PERMISSION', undefined)
+
+    const config = new ServerConfig()
+
+    expect(config.agentPermission).toBe('safe-edit')
+  })
+
+  it('should default AGENT_PERMISSION to safe-edit when empty string', () => {
+    vi.stubEnv('AGENTS_DIR', testAgentsDir)
+    vi.stubEnv('AGENT_PERMISSION', '')
+
+    const config = new ServerConfig()
+
+    expect(config.agentPermission).toBe('safe-edit')
+  })
+
+  it('should throw error when AGENT_PERMISSION is an unsupported value', () => {
+    vi.stubEnv('AGENTS_DIR', testAgentsDir)
+    vi.stubEnv('AGENT_PERMISSION', 'godmode')
+
+    expect(() => new ServerConfig()).toThrow(/Invalid AGENT_PERMISSION/)
+  })
+
   it('should throw error when LOG_LEVEL is an unsupported value', () => {
     vi.stubEnv('AGENTS_DIR', testAgentsDir)
     vi.stubEnv('LOG_LEVEL', 'verbose')

--- a/src/__tests__/performance/execution.test.ts
+++ b/src/__tests__/performance/execution.test.ts
@@ -210,7 +210,7 @@ describe('Execution Performance Tests', () => {
 
     server = new McpServer(config)
     agentManager = new AgentManager(config)
-    const executionConfig = createExecutionConfig('bash')
+    const executionConfig = createExecutionConfig('cursor')
     agentExecutor = new AgentExecutor(executionConfig)
 
     await server.start()

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -1,4 +1,12 @@
-import { AGENT_TYPES, type AgentType, isAgentType } from '../execution/AgentExecutor.js'
+import {
+  AGENT_PERMISSIONS,
+  AGENT_TYPES,
+  type AgentPermission,
+  type AgentType,
+  DEFAULT_AGENT_PERMISSION,
+  isAgentPermission,
+  isAgentType,
+} from '../execution/AgentExecutor.js'
 import { isLogLevel, LOG_LEVELS, type LogLevel } from '../utils/Logger.js'
 
 /**
@@ -12,6 +20,7 @@ import { isLogLevel, LOG_LEVELS, type LogLevel } from '../utils/Logger.js'
  * - SERVER_VERSION: Version of the MCP server (default: '1.0.0')
  * - AGENTS_DIR: Directory containing agent definition files (REQUIRED - must be absolute path)
  * - AGENT_TYPE: Type of agent to use ('cursor' | 'claude' | 'gemini' | 'codex') (default: 'cursor')
+ * - AGENT_PERMISSION: Approval/sandbox level for sub-agents ('read-only' | 'safe-edit' | 'yolo') (default: 'safe-edit')
  * - LOG_LEVEL: Log level for server operations (default: 'info')
  * - SESSION_ENABLED: Enable session management functionality (default: false)
  * - SESSION_DIR: Directory for storing session files (default: '.mcp-sessions')
@@ -30,6 +39,9 @@ export class ServerConfig {
 
   /** Type of agent to use for execution */
   public readonly agentType: AgentType
+
+  /** Approval/sandbox level for sub-agent execution */
+  public readonly agentPermission: AgentPermission
 
   /** Log level for server operations */
   public readonly logLevel: LogLevel
@@ -87,6 +99,17 @@ export class ServerConfig {
     } else {
       throw new Error(
         `Invalid AGENT_TYPE: "${agentTypeEnv}". Must be one of: ${AGENT_TYPES.join(', ')}.`
+      )
+    }
+
+    const agentPermissionEnv = process.env['AGENT_PERMISSION']?.trim()
+    if (!agentPermissionEnv) {
+      this.agentPermission = DEFAULT_AGENT_PERMISSION
+    } else if (isAgentPermission(agentPermissionEnv)) {
+      this.agentPermission = agentPermissionEnv
+    } else {
+      throw new Error(
+        `Invalid AGENT_PERMISSION: "${agentPermissionEnv}". Must be one of: ${AGENT_PERMISSIONS.join(', ')}.`
       )
     }
 

--- a/src/execution/AgentExecutor.ts
+++ b/src/execution/AgentExecutor.ts
@@ -62,6 +62,16 @@ export interface ExecutionConfig {
   agentType: AgentType
 
   /**
+   * Approval/sandbox level the sub-agent runs with.
+   *
+   * Sub-agents have no stdin, so any approval prompt would deadlock the run.
+   * The default 'safe-edit' keeps writes confined to the workspace while
+   * suppressing prompts. The default value is owned by ServerConfig and
+   * threaded through here; this field is required.
+   */
+  permission: AgentPermission
+
+  /**
    * Path to CLI settings file/directory.
    * Applied differently based on agentType:
    * - claude: passed as --settings argument
@@ -93,6 +103,58 @@ export function isAgentType(value: unknown): value is AgentType {
 }
 
 /**
+ * Supported permission levels. Single source of truth for both runtime
+ * validation (ServerConfig) and static typing.
+ */
+export const AGENT_PERMISSIONS = ['read-only', 'safe-edit', 'yolo'] as const
+
+export type AgentPermission = (typeof AGENT_PERMISSIONS)[number]
+
+export function isAgentPermission(value: unknown): value is AgentPermission {
+  return typeof value === 'string' && (AGENT_PERMISSIONS as readonly string[]).includes(value)
+}
+
+/**
+ * Default permission level used when AGENT_PERMISSION is not set.
+ * Owned here so ServerConfig and createExecutionConfig share a single constant.
+ */
+export const DEFAULT_AGENT_PERMISSION: AgentPermission = 'safe-edit'
+
+/**
+ * Permission level → per-CLI flag mapping.
+ *
+ * Levels:
+ * - 'read-only': investigation/review only, no edits or shell writes.
+ * - 'safe-edit' (default): auto-approve edits inside the workspace, suppress prompts.
+ * - 'yolo': bypass all approvals and sandboxing.
+ *
+ * Order is preserved when these flags are spliced into argv; tests assert
+ * exact arrays via toEqual, so any change here must be reflected in tests.
+ */
+const PERMISSION_FLAGS: Record<AgentType, Record<AgentPermission, readonly string[]>> = {
+  codex: {
+    'read-only': ['-s', 'read-only'],
+    'safe-edit': ['-s', 'workspace-write', '-c', 'approval_policy=never'],
+    yolo: ['--dangerously-bypass-approvals-and-sandbox'],
+  },
+  claude: {
+    'read-only': ['--permission-mode', 'plan'],
+    'safe-edit': ['--permission-mode', 'acceptEdits'],
+    yolo: ['--dangerously-skip-permissions'],
+  },
+  gemini: {
+    'read-only': ['--approval-mode', 'plan'],
+    'safe-edit': ['--approval-mode', 'auto_edit'],
+    yolo: ['-y'],
+  },
+  cursor: {
+    'read-only': ['--mode', 'plan'],
+    'safe-edit': ['--trust'],
+    yolo: ['-f', '--trust'],
+  },
+}
+
+/**
  * Creates a complete ExecutionConfig with the provided agent type.
  * @param agentType - The type of agent to use
  * @param overrides - Optional overrides for configuration values
@@ -101,9 +163,13 @@ export function createExecutionConfig(
   agentType: AgentType,
   overrides?: Partial<Omit<ExecutionConfig, 'agentType'>>
 ): ExecutionConfig {
+  // permission is applied via `??` rather than letting the spread overwrite the
+  // default, so a caller passing `{ permission: undefined }` (e.g. via a mock
+  // that bypasses TS) does not silently disable approval handling.
   return {
     executionTimeout: DEFAULT_EXECUTION_TIMEOUT,
     ...overrides,
+    permission: overrides?.permission ?? DEFAULT_AGENT_PERMISSION,
     agentType,
   }
 }
@@ -232,9 +298,10 @@ export class AgentExecutor {
   /**
    * Builds CLI-specific command, args, and environment overrides.
    *
-   * - Claude: uses --append-system-prompt to separate agent definition from user prompt
-   * - Gemini: uses GEMINI_SYSTEM_MD env var pointing to the agent definition file
-   * - Codex/Cursor: concatenates system context and user prompt (no separation)
+   * Each CLI's argv layout follows the pattern: permission flags first
+   * (so the per-CLI base flags and the prompt remain at the tail). Per-CLI
+   * specifics (system-prompt injection, settings path, API key) are handled
+   * by the dedicated builder.
    *
    * @private
    */
@@ -243,74 +310,118 @@ export class AgentExecutor {
     args: string[]
     envOverrides: Record<string, string>
   } {
-    const envOverrides: Record<string, string> = {}
+    const envOverrides = this.buildSettingsPathEnv()
 
-    // Apply CLI-specific settings path configuration
+    switch (this.config.agentType) {
+      case 'codex':
+        return this.buildCodexArgs(params, envOverrides)
+      case 'claude':
+        return this.buildClaudeArgs(params, envOverrides)
+      case 'gemini':
+        return this.buildGeminiArgs(params, envOverrides)
+      case 'cursor':
+        return this.buildCursorArgs(params, envOverrides)
+    }
+  }
+
+  /**
+   * Maps AGENTS_SETTINGS_PATH onto the per-CLI env var (claude is handled
+   * via argv, gemini does not support it). Gemini ignoring this is a known
+   * upstream limitation, not a bug here.
+   *
+   * @private
+   */
+  private buildSettingsPathEnv(): Record<string, string> {
+    const env: Record<string, string> = {}
+    if (!this.config.agentsSettingsPath) return env
+    switch (this.config.agentType) {
+      case 'cursor':
+        env['CURSOR_CONFIG_DIR'] = this.config.agentsSettingsPath
+        break
+      case 'codex':
+        env['CODEX_HOME'] = this.config.agentsSettingsPath
+        break
+      // claude: handled via --settings argv below
+      // gemini: not supported (upstream limitation)
+    }
+    return env
+  }
+
+  private permissionFlags(): readonly string[] {
+    return PERMISSION_FLAGS[this.config.agentType][this.config.permission]
+  }
+
+  private buildCodexArgs(
+    params: ExecutionParams,
+    envOverrides: Record<string, string>
+  ): { command: string; args: string[]; envOverrides: Record<string, string> } {
+    const perm = this.permissionFlags()
+    // System context is concatenated into the user prompt rather than injected
+    // via `-c model_instructions_file=...`: that flag fully replaces codex's
+    // default system prompt, which removed the built-in tool-use guidance and
+    // measurably increased exploration overhead and token usage in our tests.
+    // Concatenation keeps codex's defaults intact and matches the cursor path.
+    const formattedPrompt = `[System Context]\n${params.agent}\n\n[User Prompt]\n${params.prompt}`
+    const args = [...perm, 'exec', '--json', '--skip-git-repo-check', formattedPrompt]
+    return { command: 'codex', args, envOverrides }
+  }
+
+  private buildClaudeArgs(
+    params: ExecutionParams,
+    envOverrides: Record<string, string>
+  ): { command: string; args: string[]; envOverrides: Record<string, string> } {
+    const perm = this.permissionFlags()
+    const cwd = params.cwd || process.cwd()
+    const systemPrompt = `cwd: ${cwd}\n\n${params.agent}`
+    const args: string[] = [
+      ...perm,
+      '--output-format',
+      'stream-json',
+      '--verbose',
+      '--append-system-prompt',
+      systemPrompt,
+      '-p',
+      params.prompt,
+    ]
     if (this.config.agentsSettingsPath) {
-      switch (this.config.agentType) {
-        case 'cursor':
-          envOverrides['CURSOR_CONFIG_DIR'] = this.config.agentsSettingsPath
-          break
-        case 'codex':
-          envOverrides['CODEX_HOME'] = this.config.agentsSettingsPath
-          break
-        // claude: handled via --settings argument below
-        // gemini: not supported (upstream limitation)
+      args.push('--settings', this.config.agentsSettingsPath)
+    }
+    return { command: 'claude', args, envOverrides }
+  }
+
+  private buildGeminiArgs(
+    params: ExecutionParams,
+    envOverrides: Record<string, string>
+  ): { command: string; args: string[]; envOverrides: Record<string, string> } {
+    const perm = this.permissionFlags()
+    // --skip-trust is unconditional: headless runs in untrusted folders are
+    // refused without it (Gemini downgrades to interactive prompts which
+    // deadlock here since we have no stdin).
+    if (params.agentFilePath) {
+      const args = [...perm, '--skip-trust', '--output-format', 'stream-json', '-p', params.prompt]
+      return {
+        command: 'gemini',
+        args,
+        envOverrides: { ...envOverrides, GEMINI_SYSTEM_MD: params.agentFilePath },
       }
     }
+    const formattedPrompt = `[System Context]\n${params.agent}\n\n[User Prompt]\n${params.prompt}`
+    const args = [...perm, '--skip-trust', '--output-format', 'stream-json', '-p', formattedPrompt]
+    return { command: 'gemini', args, envOverrides }
+  }
 
-    if (this.config.agentType === 'codex') {
-      const formattedPrompt = `[System Context]\n${params.agent}\n\n[User Prompt]\n${params.prompt}`
-      return { command: 'codex', args: ['exec', '--json', formattedPrompt], envOverrides }
+  private buildCursorArgs(
+    params: ExecutionParams,
+    envOverrides: Record<string, string>
+  ): { command: string; args: string[]; envOverrides: Record<string, string> } {
+    const perm = this.permissionFlags()
+    const formattedPrompt = `[System Context]\n${params.agent}\n\n[User Prompt]\n${params.prompt}`
+    const args = [...perm, '--output-format', 'json', '-p', formattedPrompt]
+    const env: Record<string, string> = { ...envOverrides }
+    if (this.config.cursorApiKey) {
+      env['CURSOR_API_KEY'] = this.config.cursorApiKey
     }
-
-    // Determine command
-    const command =
-      this.config.agentType === 'claude'
-        ? 'claude'
-        : this.config.agentType === 'gemini'
-          ? 'gemini'
-          : 'cursor-agent'
-
-    let args: string[]
-
-    if (this.config.agentType === 'claude') {
-      // Claude: separate system prompt via --append-system-prompt
-      const cwd = params.cwd || process.cwd()
-      const systemPrompt = `cwd: ${cwd}\n\n${params.agent}`
-      args = [
-        '--output-format',
-        'stream-json',
-        '--verbose',
-        '--append-system-prompt',
-        systemPrompt,
-        '-p',
-        params.prompt,
-      ]
-
-      if (this.config.agentsSettingsPath) {
-        args.push('--settings', this.config.agentsSettingsPath)
-      }
-    } else if (this.config.agentType === 'gemini' && params.agentFilePath) {
-      // Gemini: pass agent file as system prompt via env var
-      args = ['--output-format', 'stream-json', '-p', params.prompt]
-      envOverrides['GEMINI_SYSTEM_MD'] = params.agentFilePath
-    } else {
-      // Cursor or Gemini without agentFilePath: concatenate as before
-      const formattedPrompt = `[System Context]\n${params.agent}\n\n[User Prompt]\n${params.prompt}`
-      if (this.config.agentType === 'gemini') {
-        args = ['--output-format', 'stream-json', '-p', formattedPrompt]
-      } else {
-        args = ['--output-format', 'json', '-p', formattedPrompt]
-      }
-    }
-
-    // Pass API key for cursor-agent via environment variable (not CLI arg, to avoid ps exposure)
-    if (this.config.agentType === 'cursor' && this.config.cursorApiKey) {
-      envOverrides['CURSOR_API_KEY'] = this.config.cursorApiKey
-    }
-
-    return { command, args, envOverrides }
+    return { command: 'cursor-agent', args, envOverrides: env }
   }
 
   /**

--- a/src/execution/__tests__/AgentExecutor.test.ts
+++ b/src/execution/__tests__/AgentExecutor.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ExecutionParams } from '../../types/ExecutionParams.js'
 import {
   AgentExecutor,
+  type AgentPermission,
+  type AgentType,
   createExecutionConfig,
   DEFAULT_EXECUTION_TIMEOUT,
 } from '../AgentExecutor.js'
@@ -521,6 +523,143 @@ describe('AgentExecutor', () => {
 
       expect(result.exitCode).not.toBe(0)
       expect(result.stderr).toContain('timeout')
+    })
+  })
+
+  describe('permission flag mapping', () => {
+    type Case = {
+      agent: AgentType
+      perm: AgentPermission
+      expected: readonly string[]
+    }
+
+    const cases: readonly Case[] = [
+      // codex
+      { agent: 'codex', perm: 'read-only', expected: ['-s', 'read-only'] },
+      {
+        agent: 'codex',
+        perm: 'safe-edit',
+        expected: ['-s', 'workspace-write', '-c', 'approval_policy=never'],
+      },
+      { agent: 'codex', perm: 'yolo', expected: ['--dangerously-bypass-approvals-and-sandbox'] },
+      // claude
+      { agent: 'claude', perm: 'read-only', expected: ['--permission-mode', 'plan'] },
+      { agent: 'claude', perm: 'safe-edit', expected: ['--permission-mode', 'acceptEdits'] },
+      { agent: 'claude', perm: 'yolo', expected: ['--dangerously-skip-permissions'] },
+      // gemini
+      { agent: 'gemini', perm: 'read-only', expected: ['--approval-mode', 'plan'] },
+      { agent: 'gemini', perm: 'safe-edit', expected: ['--approval-mode', 'auto_edit'] },
+      { agent: 'gemini', perm: 'yolo', expected: ['-y'] },
+      // cursor
+      { agent: 'cursor', perm: 'read-only', expected: ['--mode', 'plan'] },
+      { agent: 'cursor', perm: 'safe-edit', expected: ['--trust'] },
+      { agent: 'cursor', perm: 'yolo', expected: ['-f', '--trust'] },
+    ]
+
+    it.each(cases)('should prepend $expected for agent=$agent permission=$perm', async ({
+      agent,
+      perm,
+      expected,
+    }) => {
+      const executor = new AgentExecutor(createExecutionConfig(agent, { permission: perm }))
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      const args = mockSpawn.mock.calls[0][1] as string[]
+      // Permission flags must occupy the head of argv (before the per-CLI base flags).
+      expect(args.slice(0, expected.length)).toEqual(expected)
+    })
+
+    it('should default to safe-edit when permission is not specified in createExecutionConfig', async () => {
+      const executor = new AgentExecutor(createExecutionConfig('claude'))
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      const args = mockSpawn.mock.calls[0][1] as string[]
+      expect(args.slice(0, 2)).toEqual(['--permission-mode', 'acceptEdits'])
+    })
+
+    it('should fall back to safe-edit when overrides.permission is undefined (mocks bypassing TS)', async () => {
+      // Simulates a test mock or JS caller that passes { permission: undefined }
+      // — without the `??` guard the spread would overwrite the default and
+      // leave the sub-agent without any approval flag, deadlocking on prompt.
+      const executor = new AgentExecutor(
+        createExecutionConfig('claude', { permission: undefined as unknown as AgentPermission })
+      )
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      const args = mockSpawn.mock.calls[0][1] as string[]
+      expect(args.slice(0, 2)).toEqual(['--permission-mode', 'acceptEdits'])
+    })
+  })
+
+  describe('new required CLI flags', () => {
+    it('should include --skip-git-repo-check for codex', async () => {
+      const executor = new AgentExecutor(createExecutionConfig('codex'))
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      const args = mockSpawn.mock.calls[0][1] as string[]
+      expect(args).toContain('--skip-git-repo-check')
+    })
+
+    it('should include --skip-trust for gemini unconditionally', async () => {
+      const executor = new AgentExecutor(createExecutionConfig('gemini'))
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      const args = mockSpawn.mock.calls[0][1] as string[]
+      expect(args).toContain('--skip-trust')
+    })
+
+    it('should include --skip-trust for gemini even when agentFilePath is provided', async () => {
+      const executor = new AgentExecutor(createExecutionConfig('gemini'))
+
+      await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Test prompt',
+        cwd: '/tmp',
+        agentFilePath: '/path/to/agent.md',
+      })
+
+      const args = mockSpawn.mock.calls[0][1] as string[]
+      expect(args).toContain('--skip-trust')
+    })
+
+    it('should not leak codex-specific flags into other CLIs', async () => {
+      for (const agent of ['claude', 'gemini', 'cursor'] as const) {
+        mockSpawn.mockClear()
+        const executor = new AgentExecutor(createExecutionConfig(agent))
+        await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+        const args = mockSpawn.mock.calls[0][1] as string[]
+        expect(args).not.toContain('--skip-git-repo-check')
+      }
+    })
+  })
+
+  describe('codex prompt assembly', () => {
+    it('should concatenate system context into the prompt regardless of agentFilePath', async () => {
+      // codex's `-c model_instructions_file` was deliberately not adopted: it
+      // replaces codex's built-in system prompt and measurably increased
+      // exploration overhead and token usage in real-task comparisons.
+      const executor = new AgentExecutor(createExecutionConfig('codex'))
+
+      await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Test prompt',
+        cwd: '/tmp',
+        agentFilePath: '/path/to/agent.md',
+      })
+
+      const args = mockSpawn.mock.calls[0][1] as string[]
+      const promptArg = args[args.length - 1]
+      expect(promptArg).toContain('[System Context]')
+      expect(promptArg).toContain('test-agent')
+      expect(promptArg).toContain('[User Prompt]')
+      expect(promptArg).toContain('Test prompt')
+      // model_instructions_file must never appear in argv.
+      expect(args.some((a) => a.startsWith('model_instructions_file='))).toBe(false)
     })
   })
 

--- a/src/server/McpServer.ts
+++ b/src/server/McpServer.ts
@@ -74,7 +74,8 @@ export class McpServer {
 
     // Create ExecutionConfig with the agent type from server config
     const executionConfig = createExecutionConfig(config.agentType, {
-      executionTimeout: config.executionTimeoutMs, // Use timeout from config (env var or 90s default)
+      executionTimeout: config.executionTimeoutMs,
+      permission: config.agentPermission,
       ...(config.agentsSettingsPath && { agentsSettingsPath: config.agentsSettingsPath }),
       ...(config.cursorApiKey && { cursorApiKey: config.cursorApiKey }),
     })


### PR DESCRIPTION
## Summary
- Aligns each backend (codex/claude/gemini/cursor-agent) with its current CLI surface so sub-agents no longer rely on each CLI's interactive defaults (which would deadlock here since stdin is closed).
- Introduces a server-wide `AGENT_PERMISSION` env (`read-only` / `safe-edit` / `yolo`, default `safe-edit`) so operators can pick a coarse approval/sandbox level per server instance.
- Bumps version 0.7.1 → 0.8.0 (minor: new env, behavior change, engine restriction).

## Why now
Each backend CLI has shifted under us:
- **codex 0.128.0** runs outside Git repos require `--skip-git-repo-check`; permission must be set explicitly via `-s` and `-c approval_policy=...`.
- **gemini 0.41+** refuses headless runs in untrusted folders without `--skip-trust`.
- All four expose first-class headless permission/approval modes that we were not driving.

Without these flags, sub-agents either fall back to interactive prompts (deadlock without stdin) or run with the CLI's safest mode, which differs per CLI.

## What changed

### `AGENT_PERMISSION` env
New optional env (default `safe-edit`). Validated at startup in `ServerConfig` using the same shape as `AGENT_TYPE` / `LOG_LEVEL`. Threaded through `ExecutionConfig` and consumed by per-CLI argv builders. `createExecutionConfig` falls back via `?? DEFAULT_AGENT_PERMISSION` so a caller passing `{ permission: undefined }` (e.g. via a mock that bypasses TS) cannot silently disable approval handling.

### Per-CLI flag mapping
Single lookup table prepended to argv:

| | `read-only` | `safe-edit` (default) | `yolo` |
|---|---|---|---|
| codex | `-s read-only` | `-s workspace-write -c approval_policy=never` | `--dangerously-bypass-approvals-and-sandbox` |
| claude | `--permission-mode plan` | `--permission-mode acceptEdits` | `--dangerously-skip-permissions` |
| gemini | `--approval-mode plan` | `--approval-mode auto_edit` | `-y` |
| cursor-agent | `--mode plan` | `--trust` | `-f --trust` |

Plus unconditional new flags:
- codex: `--skip-git-repo-check`
- gemini: `--skip-trust`

### `buildCommandArgs` refactor
Split into four per-CLI private builders (`buildCodexArgs` / `buildClaudeArgs` / `buildGeminiArgs` / `buildCursorArgs`). The dispatch is an exhaustive switch on `AgentType`. No new files / no strategy hierarchy.

### Codex system-prompt injection: keep concatenation (deliberate)
Considered switching codex to `-c model_instructions_file="<path>"` (matches the sub-agents-skills approach). A real-task A/B comparison on this very repo (designer agent producing a small Design Doc) showed:

| | concat | replace (`model_instructions_file`) | ratio |
|---|---:|---:|---:|
| input tokens | 50,787 | 139,061 | **2.74x** |
| output tokens | 871 | 2,336 | 2.68x |
| reasoning tokens | 139 | 1,097 | 7.89x |
| shell commands | 6 | 15 | 2.50x |

The replace path fully supplants codex's built-in system prompt, so the model loses default tool-use guidance and explores defensively. Concatenation keeps codex's defaults intact and matches the cursor path. Kept the old behavior.

### `server.json`
- Declared `AGENT_PERMISSION`.
- Declared `CURSOR_API_KEY` (`isSecret: true`) — used by the code already but never declared.
- Fixed `AGENT_TYPE` description to include `codex`.

### `engines.node`: `>=22` → `>=22.22.2`
- `lint-staged@17` requires `>=22.22.1`; our previous `>=22` made `npm ci --engine-strict` and the pre-commit hook fragile for users on Node 22.0.0–22.22.1.
- 22.22.2 is the current 22.x security release; 22.22.1 is a regression fix release. Going one step further aligns with the LTS security line and is what we run locally.
- `package-lock.json` root engines synced.

### Performance test pre-existing dead config
`createExecutionConfig('bash')` had been there since the initial commit (a leftover from the early Claude Code-only era). It silently fell through to cursor-agent under the old if/else chain. The new exhaustive switch surfaces it; replaced with `'cursor'` (the production default).

### Tests
- `ServerConfig`: 4 cases for `AGENT_PERMISSION` (each value, empty string, missing, invalid).
- `AgentExecutor`: 12-row table-driven matrix covering `(agentType × permission)` with order-sensitive `toEqual` on the prepended flags.
- `--skip-git-repo-check` / `--skip-trust` presence checks plus cross-CLI leak prevention.
- `permission: undefined` regression test (defaults to `safe-edit`).
- codex prompt assembly: always concatenates regardless of `agentFilePath`; no `model_instructions_file=` in argv.
- `McpServer.integration` and `RunAgentTool.integration` mocks updated for the new required `agentPermission` field.

### README
- New `AGENT_PERMISSION` section with per-CLI flag mapping and a note that `safe-edit`'s sandbox depth varies by CLI (codex enforces a `workspace-write` sandbox; claude/gemini/cursor only auto-approve).

## Versioning
0.7.1 → **0.8.0** (minor). Pre-1.0 conventions place new env additions, runtime behavior changes (new flags now applied by default), and engine restrictions in minor.

## Test plan
- [x] `npm run check:all` (biome / lint / format / dpdm / build / vitest) — pass
- [x] 307 / 307 tests pass across 19 files
- [x] `npx tsc --noEmit` — zero new errors from this diff (pre-existing test-infra typing limitations untouched)
- [x] Live verified codex 0.128.0 honors permission flags + `--skip-git-repo-check` (production conditions: `stdin=DEVNULL`, `-s workspace-write`, `-c approval_policy=never`)
- [x] A/B codex prompt-injection comparison documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)