### PR TITLE
Add per-call timeout and permission controls to the run_agent MCP tool i

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,15 @@ Sub-agents have no stdin, so any approval prompt would deadlock the run. The def
 **`EXECUTION_TIMEOUT_MS`**
 How long agents can run before timing out (default: 5 minutes, max: 10 minutes)
 
+### Per-call overrides on `run_agent`
+
+The `run_agent` tool accepts two optional parameters that override the server-wide defaults for a single call:
+
+- **`timeout_ms`** — positive integer in milliseconds, up to **600000** (10 minutes). When omitted, the server-wide `EXECUTION_TIMEOUT_MS` (or its default) is used.
+- **`permission`** — one of `read-only`, `safe-edit`, or `yolo` (same values as `AGENT_PERMISSION`). When omitted, the server-wide `AGENT_PERMISSION` (or its default) is used.
+
+These overrides are scoped to the single call: they do not mutate the server-wide configuration and they do not leak into later calls or session policy. Invalid values (non-integer / non-positive / out-of-range `timeout_ms`, or an unknown `permission`) are rejected before the agent process is spawned and surface as an MCP error response.
+
 **`AGENTS_SETTINGS_PATH`**
 Path to custom CLI settings directory for sub-agents.
 

--- a/src/__tests__/integration/RunAgentTool.integration.test.ts
+++ b/src/__tests__/integration/RunAgentTool.integration.test.ts
@@ -613,6 +613,159 @@ describe('RunAgentTool', () => {
     })
   })
 
+  describe('per-call timeout_ms and permission controls', () => {
+    beforeEach(() => {
+      vi.spyOn(mockAgentManager, 'getAgent').mockResolvedValue({
+        name: 'test-agent',
+        description: 'Test agent',
+        content: 'Test content',
+        filePath: '/test/test-agent.md',
+        lastModified: new Date(),
+      })
+    })
+
+    it('should expose timeout_ms and permission in the input schema with bounds and enum', () => {
+      const schema = runAgentTool.inputSchema as unknown as {
+        properties: Record<string, Record<string, unknown>>
+        required: string[]
+      }
+
+      expect(schema.properties['timeout_ms']).toBeDefined()
+      expect(schema.properties['timeout_ms']?.['type']).toBe('integer')
+      expect(schema.properties['timeout_ms']?.['minimum']).toBe(1)
+      expect(schema.properties['timeout_ms']?.['maximum']).toBe(600000)
+
+      expect(schema.properties['permission']).toBeDefined()
+      expect(schema.properties['permission']?.['type']).toBe('string')
+      expect(schema.properties['permission']?.['enum']).toEqual(
+        expect.arrayContaining(['read-only', 'safe-edit', 'yolo'])
+      )
+
+      // Backwards-compatible: only the original three are required.
+      expect(schema.required).toEqual(['agent', 'prompt', 'cwd'])
+
+      // Existing properties remain.
+      expect(schema.properties['agent']).toBeDefined()
+      expect(schema.properties['prompt']).toBeDefined()
+      expect(schema.properties['cwd']).toBeDefined()
+      expect(schema.properties['extra_args']).toBeDefined()
+      expect(schema.properties['session_id']).toBeDefined()
+    })
+
+    it('should accept a minimal valid call without timeout_ms or permission (backwards compatible)', async () => {
+      const params = {
+        agent: 'test-agent',
+        prompt: 'Test prompt',
+        cwd: process.cwd(),
+      }
+
+      const executeSpy = vi.spyOn(mockAgentExecutor, 'executeAgent').mockResolvedValue({
+        stdout: 'ok',
+        stderr: '',
+        exitCode: 0,
+        executionTime: 10,
+        hasResult: false,
+        resultJson: undefined,
+      })
+
+      const result = await runAgentTool.execute(params)
+
+      expect(result.isError).not.toBe(true)
+      const forwarded = executeSpy.mock.calls[0][0]
+      expect(forwarded.timeoutMs).toBeUndefined()
+      expect(forwarded.permission).toBeUndefined()
+    })
+
+    it('should forward valid timeout_ms and permission to executeAgent', async () => {
+      const params = {
+        agent: 'test-agent',
+        prompt: 'Test prompt',
+        cwd: process.cwd(),
+        timeout_ms: 60000,
+        permission: 'read-only',
+      }
+
+      const executeSpy = vi.spyOn(mockAgentExecutor, 'executeAgent').mockResolvedValue({
+        stdout: 'ok',
+        stderr: '',
+        exitCode: 0,
+        executionTime: 10,
+        hasResult: false,
+        resultJson: undefined,
+      })
+
+      const result = await runAgentTool.execute(params)
+      expect(result.isError).not.toBe(true)
+
+      const forwarded = executeSpy.mock.calls[0][0]
+      expect(forwarded.timeoutMs).toBe(60000)
+      expect(forwarded.permission).toBe('read-only')
+    })
+
+    it.each([
+      [{ timeout_ms: 0 }, /timeout_ms.*positive/i],
+      [{ timeout_ms: -100 }, /timeout_ms.*positive/i],
+      [{ timeout_ms: 1.5 }, /timeout_ms.*integer/i],
+      [{ timeout_ms: '60000' }, /timeout_ms.*integer/i],
+      [{ timeout_ms: 600001 }, /timeout_ms.*maximum|exceeds/i],
+      [{ permission: 'admin' }, /permission.*one of/i],
+      [{ permission: '' }, /permission.*one of/i],
+      [{ permission: 123 }, /permission.*one of/i],
+    ] as const)('should reject invalid input %j with an MCP error and never spawn an agent', async (override, expectedMessage) => {
+      const params = {
+        agent: 'test-agent',
+        prompt: 'Test prompt',
+        cwd: process.cwd(),
+        ...override,
+      }
+
+      const executeSpy = vi.spyOn(mockAgentExecutor, 'executeAgent')
+
+      const result = (await runAgentTool.execute(params)) as any
+      expect(result.isError).toBe(true)
+      const textContent = result.content.find((c: any) => c.type === 'text')
+      expect(textContent?.text).toMatch(expectedMessage)
+      expect(executeSpy).not.toHaveBeenCalled()
+    })
+
+    it('should not leak per-call timeout_ms / permission into a later call on the same tool', async () => {
+      // Two sequential executions on the same RunAgentTool / AgentExecutor
+      // setup. The first overrides; the second omits the overrides, and we
+      // assert the forwarded ExecutionParams reflects "no override" — the
+      // executor's `??` fallback path then uses its configured default.
+      const executeSpy = vi.spyOn(mockAgentExecutor, 'executeAgent').mockResolvedValue({
+        stdout: 'ok',
+        stderr: '',
+        exitCode: 0,
+        executionTime: 10,
+        hasResult: false,
+        resultJson: undefined,
+      })
+
+      await runAgentTool.execute({
+        agent: 'test-agent',
+        prompt: 'first',
+        cwd: process.cwd(),
+        timeout_ms: 5000,
+        permission: 'yolo',
+      })
+
+      await runAgentTool.execute({
+        agent: 'test-agent',
+        prompt: 'second',
+        cwd: process.cwd(),
+      })
+
+      expect(executeSpy).toHaveBeenCalledTimes(2)
+      const firstParams = executeSpy.mock.calls[0][0]
+      const secondParams = executeSpy.mock.calls[1][0]
+      expect(firstParams.timeoutMs).toBe(5000)
+      expect(firstParams.permission).toBe('yolo')
+      expect(secondParams.timeoutMs).toBeUndefined()
+      expect(secondParams.permission).toBeUndefined()
+    })
+  })
+
   describe('session ID auto-generation', () => {
     it('should auto-generate session_id when not provided and SessionManager is available', async () => {
       const mockSessionManager = {

--- a/src/execution/AgentExecutor.ts
+++ b/src/execution/AgentExecutor.ts
@@ -91,6 +91,14 @@ export interface ExecutionConfig {
 export const DEFAULT_EXECUTION_TIMEOUT = 300000 // 5 minutes
 
 /**
+ * Documented upper bound for the per-call `timeout_ms` override exposed via
+ * the run_agent MCP tool. Mirrors the README's stated max for
+ * EXECUTION_TIMEOUT_MS (10 minutes); the constant lives here so the schema
+ * validator and any other consumer share a single source of truth.
+ */
+export const MAX_PER_CALL_EXECUTION_TIMEOUT = 600000 // 10 minutes
+
+/**
  * Supported agent runtimes. Single source of truth for both runtime validation
  * (ServerConfig) and static typing.
  */
@@ -241,6 +249,15 @@ export class AgentExecutor {
       extraArgs: params.extra_args?.length || 0,
     })
 
+    // Resolve per-call overrides without mutating the shared config.
+    // params.timeoutMs / params.permission are honored only for this call;
+    // any subsequent call without overrides falls back to the constructor
+    // defaults from this.config. The `??` form means an explicit `undefined`
+    // (e.g. coming from a JS caller / mock) does not silently disable the
+    // default — same rationale as createExecutionConfig's `?? DEFAULT_*`.
+    const effectiveTimeout = params.timeoutMs ?? this.config.executionTimeout
+    const effectivePermission = params.permission ?? this.config.permission
+
     try {
       // Add minimal delay to ensure execution time is measurable
       await new Promise((resolve) => setTimeout(resolve, 1))
@@ -248,7 +265,7 @@ export class AgentExecutor {
       // Use spawn method for proper TTY handling
 
       // Execute using spawn for proper TTY handling
-      const result = await this.executeWithSpawn(params)
+      const result = await this.executeWithSpawn(params, effectiveTimeout, effectivePermission)
 
       const executionTime = Date.now() - startTime
 
@@ -305,7 +322,10 @@ export class AgentExecutor {
    *
    * @private
    */
-  private buildCommandArgs(params: ExecutionParams): {
+  private buildCommandArgs(
+    params: ExecutionParams,
+    permission: AgentPermission
+  ): {
     command: string
     args: string[]
     envOverrides: Record<string, string>
@@ -314,13 +334,13 @@ export class AgentExecutor {
 
     switch (this.config.agentType) {
       case 'codex':
-        return this.buildCodexArgs(params, envOverrides)
+        return this.buildCodexArgs(params, envOverrides, permission)
       case 'claude':
-        return this.buildClaudeArgs(params, envOverrides)
+        return this.buildClaudeArgs(params, envOverrides, permission)
       case 'gemini':
-        return this.buildGeminiArgs(params, envOverrides)
+        return this.buildGeminiArgs(params, envOverrides, permission)
       case 'cursor':
-        return this.buildCursorArgs(params, envOverrides)
+        return this.buildCursorArgs(params, envOverrides, permission)
     }
   }
 
@@ -347,15 +367,16 @@ export class AgentExecutor {
     return env
   }
 
-  private permissionFlags(): readonly string[] {
-    return PERMISSION_FLAGS[this.config.agentType][this.config.permission]
+  private permissionFlags(permission: AgentPermission): readonly string[] {
+    return PERMISSION_FLAGS[this.config.agentType][permission]
   }
 
   private buildCodexArgs(
     params: ExecutionParams,
-    envOverrides: Record<string, string>
+    envOverrides: Record<string, string>,
+    permission: AgentPermission
   ): { command: string; args: string[]; envOverrides: Record<string, string> } {
-    const perm = this.permissionFlags()
+    const perm = this.permissionFlags(permission)
     // System context is concatenated into the user prompt rather than injected
     // via `-c model_instructions_file=...`: that flag fully replaces codex's
     // default system prompt, which removed the built-in tool-use guidance and
@@ -368,9 +389,10 @@ export class AgentExecutor {
 
   private buildClaudeArgs(
     params: ExecutionParams,
-    envOverrides: Record<string, string>
+    envOverrides: Record<string, string>,
+    permission: AgentPermission
   ): { command: string; args: string[]; envOverrides: Record<string, string> } {
-    const perm = this.permissionFlags()
+    const perm = this.permissionFlags(permission)
     const cwd = params.cwd || process.cwd()
     const systemPrompt = `cwd: ${cwd}\n\n${params.agent}`
     const args: string[] = [
@@ -391,9 +413,10 @@ export class AgentExecutor {
 
   private buildGeminiArgs(
     params: ExecutionParams,
-    envOverrides: Record<string, string>
+    envOverrides: Record<string, string>,
+    permission: AgentPermission
   ): { command: string; args: string[]; envOverrides: Record<string, string> } {
-    const perm = this.permissionFlags()
+    const perm = this.permissionFlags(permission)
     // --skip-trust is unconditional: headless runs in untrusted folders are
     // refused without it (Gemini downgrades to interactive prompts which
     // deadlock here since we have no stdin).
@@ -412,9 +435,10 @@ export class AgentExecutor {
 
   private buildCursorArgs(
     params: ExecutionParams,
-    envOverrides: Record<string, string>
+    envOverrides: Record<string, string>,
+    permission: AgentPermission
   ): { command: string; args: string[]; envOverrides: Record<string, string> } {
-    const perm = this.permissionFlags()
+    const perm = this.permissionFlags(permission)
     const formattedPrompt = `[System Context]\n${params.agent}\n\n[User Prompt]\n${params.prompt}`
     const args = [...perm, '--output-format', 'json', '-p', formattedPrompt]
     const env: Record<string, string> = { ...envOverrides }
@@ -431,7 +455,11 @@ export class AgentExecutor {
    * @param params - Execution parameters
    * @returns Promise resolving to execution result
    */
-  private async executeWithSpawn(params: ExecutionParams): Promise<{
+  private async executeWithSpawn(
+    params: ExecutionParams,
+    timeoutMs: number,
+    permission: AgentPermission
+  ): Promise<{
     stdout: string
     stderr: string
     exitCode: number
@@ -440,7 +468,7 @@ export class AgentExecutor {
   }> {
     return new Promise((resolve) => {
       // Build command, args, and env based on agent type with system prompt separation
-      const { command, args, envOverrides } = this.buildCommandArgs(params)
+      const { command, args, envOverrides } = this.buildCommandArgs(params, permission)
 
       // Build environment variables for spawn
       const spawnEnv: NodeJS.ProcessEnv = { ...process.env, ...envOverrides }
@@ -467,7 +495,7 @@ export class AgentExecutor {
       // No need to handle stdin as it's set to 'ignore'
       const executionTimeout = setTimeout(() => {
         this.logger.warn('Execution timeout reached', {
-          timeout: this.config.executionTimeout,
+          timeout: timeoutMs,
         })
         childProcess.kill('SIGTERM')
 
@@ -475,12 +503,12 @@ export class AgentExecutor {
         const result = streamProcessor.getResult()
         resolve({
           stdout: result ? JSON.stringify(result) : stdout,
-          stderr: stderr || `Execution timeout: ${this.config.executionTimeout}ms`,
+          stderr: stderr || `Execution timeout: ${timeoutMs}ms`,
           exitCode: 124, // Standard timeout exit code
           hasResult: result !== null,
           resultJson: result !== null ? result : undefined,
         })
-      }, this.config.executionTimeout)
+      }, timeoutMs)
 
       // Handle stdout stream with simplified processing
       childProcess.stdout?.on('data', (data: Buffer) => {

--- a/src/execution/__tests__/AgentExecutor.test.ts
+++ b/src/execution/__tests__/AgentExecutor.test.ts
@@ -638,6 +638,150 @@ describe('AgentExecutor', () => {
     })
   })
 
+  describe('per-call permission override', () => {
+    type Case = {
+      agent: AgentType
+      perm: AgentPermission
+      expected: readonly string[]
+    }
+
+    // Same matrix as the configured-permission test, but supplied per call
+    // via ExecutionParams.permission instead of createExecutionConfig.
+    const cases: readonly Case[] = [
+      // codex
+      { agent: 'codex', perm: 'read-only', expected: ['-s', 'read-only'] },
+      {
+        agent: 'codex',
+        perm: 'safe-edit',
+        expected: ['-s', 'workspace-write', '-c', 'approval_policy=never'],
+      },
+      { agent: 'codex', perm: 'yolo', expected: ['--dangerously-bypass-approvals-and-sandbox'] },
+      // claude
+      { agent: 'claude', perm: 'read-only', expected: ['--permission-mode', 'plan'] },
+      { agent: 'claude', perm: 'safe-edit', expected: ['--permission-mode', 'acceptEdits'] },
+      { agent: 'claude', perm: 'yolo', expected: ['--dangerously-skip-permissions'] },
+      // gemini
+      { agent: 'gemini', perm: 'read-only', expected: ['--approval-mode', 'plan'] },
+      { agent: 'gemini', perm: 'safe-edit', expected: ['--approval-mode', 'auto_edit'] },
+      { agent: 'gemini', perm: 'yolo', expected: ['-y'] },
+      // cursor
+      { agent: 'cursor', perm: 'read-only', expected: ['--mode', 'plan'] },
+      { agent: 'cursor', perm: 'safe-edit', expected: ['--trust'] },
+      { agent: 'cursor', perm: 'yolo', expected: ['-f', '--trust'] },
+    ]
+
+    it.each(
+      cases
+    )('should apply per-call permission=$perm for agent=$agent without mutating config', async ({
+      agent,
+      perm,
+      expected,
+    }) => {
+      // Configure executor with a *different* default than the per-call value
+      // so a leaked override would obviously change the next call's argv.
+      const defaultPerm: AgentPermission = perm === 'read-only' ? 'safe-edit' : 'read-only'
+      const executor = new AgentExecutor(createExecutionConfig(agent, { permission: defaultPerm }))
+
+      await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Test prompt',
+        cwd: '/tmp',
+        permission: perm,
+      })
+
+      const overrideArgs = mockSpawn.mock.calls[0][1] as string[]
+      expect(overrideArgs.slice(0, expected.length)).toEqual(expected)
+    })
+
+    it('should not leak per-call permission into a later call on the same executor', async () => {
+      const executor = new AgentExecutor(
+        createExecutionConfig('claude', { permission: 'safe-edit' })
+      )
+
+      // First call overrides to read-only
+      await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'first',
+        cwd: '/tmp',
+        permission: 'read-only',
+      })
+
+      // Second call has no override — must fall back to the configured default
+      await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'second',
+        cwd: '/tmp',
+      })
+
+      const firstArgs = mockSpawn.mock.calls[0][1] as string[]
+      const secondArgs = mockSpawn.mock.calls[1][1] as string[]
+      expect(firstArgs.slice(0, 2)).toEqual(['--permission-mode', 'plan'])
+      expect(secondArgs.slice(0, 2)).toEqual(['--permission-mode', 'acceptEdits'])
+    })
+  })
+
+  describe('per-call timeout override', () => {
+    it('should use the per-call timeout instead of the configured default', async () => {
+      mockSpawn.mockImplementationOnce(() =>
+        createMockProcess({
+          noClose: true, // never finishes — only the timeout will resolve
+        })
+      )
+
+      // Configured default is large (5 minutes) — if the override leaks through
+      // as 50ms, the test would still pass; if it does NOT, the test would
+      // hang for 5 minutes. The override is the only way the test completes
+      // quickly.
+      const executor = new AgentExecutor(
+        createExecutionConfig('cursor', { executionTimeout: 300_000 })
+      )
+
+      const start = Date.now()
+      const result = await executor.executeAgent({
+        agent: 'slow-agent',
+        prompt: 'override timeout',
+        cwd: '/tmp',
+        timeoutMs: 50,
+      })
+      const elapsed = Date.now() - start
+
+      expect(result.exitCode).toBe(124)
+      expect(result.stderr).toContain('timeout')
+      expect(elapsed).toBeLessThan(5_000)
+    })
+
+    it('should fall back to the configured timeout on calls without override', async () => {
+      // First call: no-close + per-call override (50ms)
+      // Second call: no-close + no override, configured timeout 80ms
+      mockSpawn.mockImplementation(() => createMockProcess({ noClose: true }))
+
+      const executor = new AgentExecutor(createExecutionConfig('cursor', { executionTimeout: 80 }))
+
+      const overrideStart = Date.now()
+      await executor.executeAgent({
+        agent: 'slow-agent',
+        prompt: 'first',
+        cwd: '/tmp',
+        timeoutMs: 50,
+      })
+      const overrideElapsed = Date.now() - overrideStart
+
+      const defaultStart = Date.now()
+      await executor.executeAgent({
+        agent: 'slow-agent',
+        prompt: 'second',
+        cwd: '/tmp',
+      })
+      const defaultElapsed = Date.now() - defaultStart
+
+      // Both must time out, and the second call's elapsed time tracks the
+      // configured default, proving the override did not mutate config.
+      expect(overrideElapsed).toBeGreaterThanOrEqual(40)
+      expect(defaultElapsed).toBeGreaterThanOrEqual(70)
+      expect(defaultElapsed).toBeLessThan(5_000)
+    })
+  })
+
   describe('codex prompt assembly', () => {
     it('should concatenate system context into the prompt regardless of agentFilePath', async () => {
       // codex's `-c model_instructions_file` was deliberately not adopted: it

--- a/src/tools/RunAgentTool.ts
+++ b/src/tools/RunAgentTool.ts
@@ -8,7 +8,14 @@
 
 import { randomUUID } from 'node:crypto'
 import type { AgentManager } from '../agents/AgentManager.js'
-import type { AgentExecutionResult, AgentExecutor } from '../execution/AgentExecutor.js'
+import {
+  AGENT_PERMISSIONS,
+  type AgentExecutionResult,
+  type AgentExecutor,
+  type AgentPermission,
+  isAgentPermission,
+  MAX_PER_CALL_EXECUTION_TIMEOUT,
+} from '../execution/AgentExecutor.js'
 import { formatSessionHistory } from '../session/SessionHistoryFormatter.js'
 import type { SessionManager } from '../session/SessionManager.js'
 import type { AgentDefinition } from '../types/AgentDefinition.js'
@@ -80,6 +87,17 @@ interface RunAgentInputSchema {
       type: 'string'
       description: string
     }
+    timeout_ms: {
+      type: 'integer'
+      minimum: number
+      maximum: number
+      description: string
+    }
+    permission: {
+      type: 'string'
+      enum: readonly AgentPermission[]
+      description: string
+    }
   }
   required: string[]
 }
@@ -99,6 +117,20 @@ interface RunAgentParams {
    * Must be alphanumeric with hyphens and underscores only (max 100 characters).
    */
   session_id?: string | undefined
+  /**
+   * Per-call execution timeout override in milliseconds (optional).
+   *
+   * When omitted, the executor falls back to its configured default
+   * (EXECUTION_TIMEOUT_MS / DEFAULT_EXECUTION_TIMEOUT).
+   */
+  timeout_ms?: number | undefined
+  /**
+   * Per-call permission/approval level override (optional).
+   *
+   * When omitted, the executor falls back to its configured default
+   * (AGENT_PERMISSION / DEFAULT_AGENT_PERMISSION).
+   */
+  permission?: AgentPermission | undefined
 }
 
 /**
@@ -141,6 +173,17 @@ export class RunAgentTool {
         type: 'string',
         description:
           'Session ID for continuing previous conversation context (optional). If omitted, a new session will be auto-generated and returned in response metadata. Reuse the returned session_id in subsequent calls to maintain context continuity.',
+      },
+      timeout_ms: {
+        type: 'integer',
+        minimum: 1,
+        maximum: MAX_PER_CALL_EXECUTION_TIMEOUT,
+        description: `Per-call execution timeout override in milliseconds (optional). Must be a positive integer no greater than ${MAX_PER_CALL_EXECUTION_TIMEOUT} (10 minutes). When omitted, the server-wide EXECUTION_TIMEOUT_MS / default applies. Affects only this single call and never mutates server-wide configuration or later calls.`,
+      },
+      permission: {
+        type: 'string',
+        enum: AGENT_PERMISSIONS,
+        description: `Per-call permission/approval level override (optional). One of: ${AGENT_PERMISSIONS.join(', ')}. When omitted, the server-wide AGENT_PERMISSION / default applies. Affects only this single call and never mutates server-wide configuration or later calls.`,
       },
     },
     required: ['agent', 'prompt', 'cwd'],
@@ -277,6 +320,16 @@ export class RunAgentTool {
           }),
           ...(agentDefinition?.filePath !== undefined && {
             agentFilePath: agentDefinition.filePath,
+          }),
+          // Per-call overrides: scoped to this single executeAgent call only.
+          // AgentExecutor reads these via `??` against this.config and never
+          // mutates the shared config, so subsequent calls without overrides
+          // fall back to the server-wide defaults.
+          ...(validatedParams.timeout_ms !== undefined && {
+            timeoutMs: validatedParams.timeout_ms,
+          }),
+          ...(validatedParams.permission !== undefined && {
+            permission: validatedParams.permission,
           }),
         }
 
@@ -488,12 +541,46 @@ export class RunAgentTool {
       }
     }
 
+    // Validate optional timeout_ms parameter
+    // Must be a positive integer within the documented upper bound. We reject
+    // before reaching executeAgent so an invalid input never spawns a process
+    // (the per-call override applies only on the resolved path).
+    let timeoutMs: number | undefined
+    if (p['timeout_ms'] !== undefined) {
+      const raw = p['timeout_ms']
+      if (typeof raw !== 'number' || !Number.isInteger(raw) || !Number.isFinite(raw)) {
+        throw new Error('timeout_ms must be a positive integer (milliseconds)')
+      }
+      if (raw <= 0) {
+        throw new Error('timeout_ms must be a positive integer (milliseconds)')
+      }
+      if (raw > MAX_PER_CALL_EXECUTION_TIMEOUT) {
+        throw new Error(
+          `timeout_ms exceeds the maximum allowed value of ${MAX_PER_CALL_EXECUTION_TIMEOUT}ms (10 minutes)`
+        )
+      }
+      timeoutMs = raw
+    }
+
+    // Validate optional permission parameter
+    // Must be one of the supported AgentPermission values. Same rejection
+    // semantics as timeout_ms.
+    let permission: AgentPermission | undefined
+    if (p['permission'] !== undefined) {
+      if (!isAgentPermission(p['permission'])) {
+        throw new Error(`permission must be one of: ${AGENT_PERMISSIONS.join(', ')}`)
+      }
+      permission = p['permission']
+    }
+
     return {
       agent: agentName,
       prompt: prompt,
       cwd: cwd,
       extra_args: p['extra_args'] as string[] | undefined,
       session_id: p['session_id'] as string | undefined,
+      timeout_ms: timeoutMs,
+      permission: permission,
     }
   }
 

--- a/src/types/ExecutionParams.ts
+++ b/src/types/ExecutionParams.ts
@@ -1,3 +1,5 @@
+import type { AgentPermission } from '../execution/AgentExecutor.js'
+
 /**
  * Parameters for executing an AI agent through the MCP server.
  * These parameters are passed to the run_agent tool to initiate agent execution.
@@ -32,6 +34,28 @@ export interface ExecutionParams {
    * Used by backends that support file-based system prompts (e.g., Gemini's GEMINI_SYSTEM_MD).
    */
   agentFilePath?: string
+
+  /**
+   * Optional per-call execution timeout override in milliseconds.
+   *
+   * When provided, this value is used in place of the executor's configured
+   * default (ExecutionConfig.executionTimeout) for this single call only. The
+   * executor never mutates its own config, so the override does not affect
+   * later calls or other concurrent calls.
+   *
+   * Validation (input bounds) is performed by the caller (e.g. RunAgentTool).
+   */
+  timeoutMs?: number
+
+  /**
+   * Optional per-call permission/approval level override.
+   *
+   * When provided, this value is used in place of the executor's configured
+   * default (ExecutionConfig.permission) for this single call only. The
+   * executor never mutates its own config, so the override does not affect
+   * later calls or other concurrent calls.
+   */
+  permission?: AgentPermission
 }
 
 /**


### PR DESCRIPTION
## Goal

Add per-call timeout and permission controls to the run_agent MCP tool in sub-agents-mcp, preserving defaults and provider mappings.

## Acceptance Criteria

- `AC1` run_agent input schema exposes optional timeout_ms and permission while preserving existing agent, prompt, cwd, session_id, and extra_args compatibility.
  - Verification: Inspect src/tools/RunAgentTool.ts schema and focused tests for schema fields and backwards-compatible valid minimal calls.
  - Status: satisfied
- `AC2` timeout_ms accepts only positive integer values within a documented upper bound; when omitted, existing EXECUTION_TIMEOUT_MS/default behavior is used.
  - Verification: Focused validation tests cover valid timeout, non-integer/negative/zero/too-large timeout, and default fallback.
  - Status: satisfied
- `AC3` permission accepts only the existing AgentPermission values read-only, safe-edit, and yolo; when omitted, existing AGENT_PERMISSION/default behavior is used.
  - Verification: Focused validation and execution tests cover valid permissions, invalid permissions, and default fallback.
  - Status: satisfied
- `AC4` Per-call timeout_ms and permission affect only the current executeAgent call and do not mutate server-wide execution config or leak into later calls or session policy.
  - Verification: Tests execute multiple calls against one RunAgentTool/AgentExecutor setup and verify later calls use default config after an override call.
  - Status: satisfied
- `AC5` AgentExecutor applies per-call permission flags correctly for cursor, claude, gemini, and codex without regressing existing provider flag mappings.
  - Verification: Provider mapping tests assert argv for all supported providers and permissions, including per-call overrides.
  - Status: satisfied
- `AC6` Invalid timeout_ms or permission inputs return MCP error responses and do not spawn an agent process.
  - Verification: RunAgentTool tests spy on executeAgent or the spawn boundary and assert invalid inputs stop before execution.
  - Status: satisfied
- `AC7` Documentation and tests are updated, and build, check, and test commands pass.
  - Verification: npm run build, npm run check, and npm test pass.
  - Status: satisfied

## Final Verification

- `npm run check:deps`: passed
- `npm run build`: passed
- `npm test`: passed
- `npm run check`: passed

## Key Decisions

- `requeue-2` Why was this task requeued? -> retry codex supervisor timeout to check reproducibility
  - Rationale: A reviewer or PR comment requested another executor attempt.
  - Reversibility: high
- `claude-decision-3` Where should the documented upper bound for timeout_ms live? -> Export MAX_PER_CALL_EXECUTION_TIMEOUT (600000ms / 10 minutes) from AgentExecutor.ts and reuse it in both the schema (maximum) and validator (range check), with README stating the same value.
  - Rationale: Single source of truth keeps schema, runtime validation, and documentation aligned, mirroring the pattern already used for AGENT_PERMISSIONS.
  - Reversibility: high
- `claude-decision-4` How should AgentExecutor honor per-call overrides without mutating shared config? -> Compute effectiveTimeout/effectivePermission as local values via params.x ?? this.config.x inside executeAgent and pass them down to executeWithSpawn.
  - Rationale: The ?? form preserves defaults even when a JS caller passes explicit undefined (matching the existing createExecutionConfig guard), and using locals guarantees subsequent calls see the original config.
  - Reversibility: high
