### PR TITLE
Add per-call timeout and permission controls to the run_agent MCP tool w

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,15 @@ Sub-agents have no stdin, so any approval prompt would deadlock the run. The def
 **`EXECUTION_TIMEOUT_MS`**
 How long agents can run before timing out (default: 5 minutes, max: 10 minutes)
 
+### Per-Call Overrides on `run_agent`
+
+The `run_agent` MCP tool accepts two optional, **execution-only** parameters that override the corresponding server-wide defaults for a single call:
+
+- **`timeout_ms`** — positive integer, between 1 and 600000 (10 minutes). Overrides `EXECUTION_TIMEOUT_MS` for this call only. When omitted, the server-wide `EXECUTION_TIMEOUT_MS` (or its default) is used.
+- **`permission`** — one of `"read-only"`, `"safe-edit"`, or `"yolo"`. Overrides `AGENT_PERMISSION` for this call only. When omitted, the server-wide `AGENT_PERMISSION` (or its default) is used.
+
+Both controls are **execution-only**: they affect only the current `run_agent` invocation, never mutate server-wide configuration, and are **not** persisted to the session history. A subsequent `run_agent` call with the same `session_id` but no overrides reverts to the server-wide defaults — the previous overrides are not replayed. Invalid values (non-integer / non-positive / over the 10-minute ceiling for `timeout_ms`, or any value outside the three permission strings) are rejected with an MCP error before any agent process is spawned and before any session entry is saved.
+
 **`AGENTS_SETTINGS_PATH`**
 Path to custom CLI settings directory for sub-agents.
 

--- a/src/__tests__/integration/RunAgentTool.per-call-controls.test.ts
+++ b/src/__tests__/integration/RunAgentTool.per-call-controls.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Focused tests for per-call timeout_ms and permission controls on run_agent.
+ *
+ * These tests cover the contract introduced for the per-call execution
+ * boundary:
+ * - schema additivity (AC1)
+ * - timeout_ms and permission validation (AC2, AC3)
+ * - per-call scope (subsequent calls revert to defaults) (AC4)
+ * - session persistence excludes execution-only controls (AC5)
+ * - invalid inputs short-circuit before spawn or session save (AC6)
+ *
+ * Tests pin behavior at the RunAgentTool boundary by spying on
+ * AgentExecutor.executeAgent (the spawn boundary) and SessionManager.saveSession
+ * (the persistence boundary).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentManager } from '../../agents/AgentManager.js'
+import type { ServerConfig } from '../../config/ServerConfig.js'
+import {
+  AGENT_PERMISSIONS,
+  AgentExecutor,
+  createExecutionConfig,
+  MAX_PER_CALL_TIMEOUT_MS,
+} from '../../execution/AgentExecutor.js'
+import { RunAgentTool } from '../../tools/RunAgentTool.js'
+
+const baseConfig: ServerConfig = {
+  serverName: 'test-server',
+  serverVersion: '1.0.0',
+  agentsDir: './test-agents',
+  agentType: 'cursor',
+  agentPermission: 'safe-edit',
+  logLevel: 'info',
+  executionTimeoutMs: 300000,
+  sessionEnabled: false,
+  sessionDir: '.mcp-sessions',
+  sessionRetentionDays: 1,
+  agentsSettingsPath: undefined,
+  cursorApiKey: undefined,
+}
+
+function newRunAgentTool() {
+  const executor = new AgentExecutor(createExecutionConfig('cursor'))
+  const manager = new AgentManager(baseConfig)
+  vi.spyOn(manager, 'getAgent').mockResolvedValue({
+    name: 'test-agent',
+    description: 'Test agent',
+    content: 'Test agent content',
+    filePath: '/test/agents/test-agent.md',
+    lastModified: new Date(),
+  })
+  const executeSpy = vi.spyOn(executor, 'executeAgent').mockResolvedValue({
+    stdout: 'ok',
+    stderr: '',
+    exitCode: 0,
+    executionTime: 1,
+    hasResult: false,
+    resultJson: undefined,
+  })
+  const sessionManager = {
+    loadSession: vi.fn().mockResolvedValue(null),
+    saveSession: vi.fn().mockResolvedValue(undefined),
+    cleanupOldSessions: vi.fn().mockResolvedValue(undefined),
+  }
+  const tool = new RunAgentTool(executor, manager, sessionManager as any)
+  return { tool, executeSpy, sessionManager }
+}
+
+const validParams = {
+  agent: 'test-agent',
+  prompt: 'Test prompt',
+  cwd: process.cwd(),
+}
+
+describe('RunAgentTool per-call controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('AC1: schema exposes optional timeout_ms and permission additively', () => {
+    it('declares timeout_ms and permission alongside existing optional fields', () => {
+      const { tool } = newRunAgentTool()
+      const schema = tool.inputSchema
+
+      // Existing required + optional contract is preserved.
+      expect(schema.required).toEqual(['agent', 'prompt', 'cwd'])
+      for (const key of ['agent', 'prompt', 'cwd', 'extra_args', 'session_id']) {
+        expect(schema.properties).toHaveProperty(key)
+      }
+
+      // New optional fields are present and not in `required`.
+      expect(schema.properties).toHaveProperty('timeout_ms')
+      expect(schema.properties).toHaveProperty('permission')
+      expect(schema.required).not.toContain('timeout_ms')
+      expect(schema.required).not.toContain('permission')
+
+      // Schema declares the per-call ceiling and permission enum so MCP
+      // clients receive the contract directly.
+      const timeoutMsSchema = schema.properties['timeout_ms'] as Record<string, unknown>
+      expect(timeoutMsSchema['type']).toBe('integer')
+      expect(timeoutMsSchema['minimum']).toBe(1)
+      expect(timeoutMsSchema['maximum']).toBe(MAX_PER_CALL_TIMEOUT_MS)
+
+      const permissionSchema = schema.properties['permission'] as Record<string, unknown>
+      expect(permissionSchema['type']).toBe('string')
+      expect(permissionSchema['enum']).toEqual(AGENT_PERMISSIONS)
+    })
+
+    it('keeps the minimal required-only call backwards compatible', async () => {
+      const { tool, executeSpy, sessionManager } = newRunAgentTool()
+
+      const result = await tool.execute({ ...validParams })
+
+      expect(result.isError).not.toBe(true)
+      expect(executeSpy).toHaveBeenCalledTimes(1)
+      // No overrides means the second arg is either omitted or empty object.
+      const overrides = executeSpy.mock.calls[0][1]
+      expect(overrides ?? {}).toEqual({})
+      expect(sessionManager.saveSession).toHaveBeenCalled()
+    })
+  })
+
+  describe('AC2: timeout_ms validation', () => {
+    it('accepts a valid positive integer within the documented bound', async () => {
+      const { tool, executeSpy } = newRunAgentTool()
+
+      const result = await tool.execute({ ...validParams, timeout_ms: 60_000 })
+
+      expect(result.isError).not.toBe(true)
+      expect(executeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ agent: 'Test agent content' }),
+        expect.objectContaining({ timeoutMs: 60_000 })
+      )
+    })
+
+    it('falls back to default when timeout_ms is omitted', async () => {
+      const { tool, executeSpy } = newRunAgentTool()
+
+      await tool.execute({ ...validParams })
+
+      const overrides = executeSpy.mock.calls[0][1]
+      expect(overrides?.timeoutMs).toBeUndefined()
+    })
+
+    it.each([
+      { label: 'non-integer', value: 1500.5 },
+      { label: 'negative', value: -1000 },
+      { label: 'zero', value: 0 },
+      { label: 'string', value: '5000' as unknown as number },
+      { label: 'NaN', value: Number.NaN },
+      { label: 'Infinity', value: Number.POSITIVE_INFINITY },
+      { label: 'too-large', value: MAX_PER_CALL_TIMEOUT_MS + 1 },
+    ])('rejects $label timeout_ms', async ({ value }) => {
+      const { tool, executeSpy, sessionManager } = newRunAgentTool()
+
+      const result = await tool.execute({ ...validParams, timeout_ms: value })
+
+      expect(result.isError).toBe(true)
+      const text = result.content.find((c) => c.type === 'text')?.text ?? ''
+      expect(text).toMatch(/timeout_ms/i)
+      expect(executeSpy).not.toHaveBeenCalled()
+      expect(sessionManager.saveSession).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('AC3: permission validation', () => {
+    it.each(AGENT_PERMISSIONS)('accepts valid permission %s', async (perm) => {
+      const { tool, executeSpy } = newRunAgentTool()
+
+      const result = await tool.execute({ ...validParams, permission: perm })
+
+      expect(result.isError).not.toBe(true)
+      expect(executeSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ permission: perm })
+      )
+    })
+
+    it('falls back to default when permission is omitted', async () => {
+      const { tool, executeSpy } = newRunAgentTool()
+
+      await tool.execute({ ...validParams })
+
+      const overrides = executeSpy.mock.calls[0][1]
+      expect(overrides?.permission).toBeUndefined()
+    })
+
+    it.each([
+      { label: 'unknown string', value: 'admin' },
+      { label: 'empty string', value: '' },
+      { label: 'wrong case', value: 'Read-Only' },
+      { label: 'number', value: 1 as unknown as string },
+      { label: 'null', value: null as unknown as string },
+    ])('rejects invalid permission ($label)', async ({ value }) => {
+      const { tool, executeSpy, sessionManager } = newRunAgentTool()
+
+      const result = await tool.execute({ ...validParams, permission: value })
+
+      expect(result.isError).toBe(true)
+      const text = result.content.find((c) => c.type === 'text')?.text ?? ''
+      expect(text).toMatch(/permission/i)
+      expect(executeSpy).not.toHaveBeenCalled()
+      expect(sessionManager.saveSession).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('AC4: per-call overrides do not mutate server-wide config', () => {
+    it('next call reverts to defaults when overrides are omitted', async () => {
+      const { tool, executeSpy } = newRunAgentTool()
+
+      await tool.execute({
+        ...validParams,
+        timeout_ms: 90_000,
+        permission: 'yolo',
+      })
+      await tool.execute({ ...validParams })
+
+      expect(executeSpy).toHaveBeenCalledTimes(2)
+      const firstOverrides = executeSpy.mock.calls[0][1] ?? {}
+      const secondOverrides = executeSpy.mock.calls[1][1] ?? {}
+
+      expect(firstOverrides).toEqual({ timeoutMs: 90_000, permission: 'yolo' })
+      // Critical: the second call must NOT inherit either override.
+      expect(secondOverrides).toEqual({})
+    })
+
+    it('different calls can carry different overrides without bleed-through', async () => {
+      const { tool, executeSpy } = newRunAgentTool()
+
+      await tool.execute({ ...validParams, timeout_ms: 5_000 })
+      await tool.execute({ ...validParams, permission: 'read-only' })
+
+      const firstOverrides = executeSpy.mock.calls[0][1] ?? {}
+      const secondOverrides = executeSpy.mock.calls[1][1] ?? {}
+
+      expect(firstOverrides).toEqual({ timeoutMs: 5_000 })
+      expect(secondOverrides).toEqual({ permission: 'read-only' })
+    })
+  })
+
+  describe('AC5: session persistence excludes execution-only controls', () => {
+    it('saved session payload omits timeout_ms and permission', async () => {
+      const { tool, sessionManager } = newRunAgentTool()
+
+      await tool.execute({
+        ...validParams,
+        session_id: 'sess-1',
+        timeout_ms: 90_000,
+        permission: 'yolo',
+      })
+
+      expect(sessionManager.saveSession).toHaveBeenCalledTimes(1)
+      const [, savedRequest] = sessionManager.saveSession.mock.calls[0]
+      expect(savedRequest).toEqual({
+        agent: 'test-agent',
+        prompt: 'Test prompt',
+        cwd: process.cwd(),
+      })
+      expect(savedRequest).not.toHaveProperty('timeout_ms')
+      expect(savedRequest).not.toHaveProperty('permission')
+    })
+
+    it('continuation call with same session_id but no overrides does not replay them', async () => {
+      const { tool, executeSpy, sessionManager } = newRunAgentTool()
+
+      // First call sets overrides — they should NOT be persisted.
+      await tool.execute({
+        ...validParams,
+        session_id: 'sess-2',
+        timeout_ms: 45_000,
+        permission: 'read-only',
+      })
+
+      // Simulate session-load on continuation. The saved history (per AC5)
+      // never carries timeout_ms / permission, so loadSession returns a
+      // payload whose history mirrors only what was saved.
+      sessionManager.loadSession.mockResolvedValueOnce({
+        sessionId: 'sess-2',
+        agentType: 'test-agent',
+        history: [
+          {
+            timestamp: new Date(),
+            request: {
+              agent: 'test-agent',
+              prompt: 'Test prompt',
+              cwd: process.cwd(),
+            },
+            response: {
+              stdout: 'ok',
+              stderr: '',
+              exitCode: 0,
+              executionTime: 1,
+            },
+          },
+        ],
+        createdAt: new Date(),
+        lastUpdatedAt: new Date(),
+      })
+
+      // Second call reuses session_id but omits both overrides.
+      await tool.execute({
+        ...validParams,
+        session_id: 'sess-2',
+      })
+
+      expect(executeSpy).toHaveBeenCalledTimes(2)
+      const continuationOverrides = executeSpy.mock.calls[1][1] ?? {}
+      // Overrides MUST NOT be inherited from the previous call.
+      expect(continuationOverrides).toEqual({})
+    })
+  })
+
+  describe('AC6: invalid inputs short-circuit before spawn and session save', () => {
+    it('invalid timeout_ms returns MCP error and never reaches executeAgent or saveSession', async () => {
+      const { tool, executeSpy, sessionManager } = newRunAgentTool()
+
+      const result = await tool.execute({
+        ...validParams,
+        session_id: 'sess-x',
+        timeout_ms: -1,
+      })
+
+      expect(result.isError).toBe(true)
+      expect(executeSpy).not.toHaveBeenCalled()
+      expect(sessionManager.saveSession).not.toHaveBeenCalled()
+    })
+
+    it('invalid permission returns MCP error and never reaches executeAgent or saveSession', async () => {
+      const { tool, executeSpy, sessionManager } = newRunAgentTool()
+
+      const result = await tool.execute({
+        ...validParams,
+        session_id: 'sess-x',
+        permission: 'super-user',
+      })
+
+      expect(result.isError).toBe(true)
+      expect(executeSpy).not.toHaveBeenCalled()
+      expect(sessionManager.saveSession).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/execution/AgentExecutor.ts
+++ b/src/execution/AgentExecutor.ts
@@ -121,6 +121,35 @@ export function isAgentPermission(value: unknown): value is AgentPermission {
 export const DEFAULT_AGENT_PERMISSION: AgentPermission = 'safe-edit'
 
 /**
+ * Maximum value accepted for a per-call timeout override (10 minutes).
+ *
+ * Mirrors the documented upper bound of EXECUTION_TIMEOUT_MS so that a
+ * per-call override never lets a single sub-agent run longer than the
+ * server-wide ceiling we publish in the README.
+ */
+export const MAX_PER_CALL_TIMEOUT_MS = 600000
+
+/**
+ * Per-call execution overrides for {@link AgentExecutor.executeAgent}.
+ *
+ * These values affect ONLY the current call. They are deliberately kept
+ * separate from {@link ExecutionConfig} so that a per-call override never
+ * mutates the server-wide defaults established at startup. Any field left
+ * undefined falls back to the corresponding {@link ExecutionConfig} value.
+ *
+ * They are also intentionally absent from {@link ExecutionParams} so that
+ * session persistence (which mirrors `ExecutionParams` shape) cannot capture
+ * them by accident.
+ */
+export interface ExecutionOverrides {
+  /** Override the execution timeout in milliseconds for this call only. */
+  timeoutMs?: number
+
+  /** Override the approval/sandbox level for this call only. */
+  permission?: AgentPermission
+}
+
+/**
  * Permission level → per-CLI flag mapping.
  *
  * Levels:
@@ -216,7 +245,10 @@ export class AgentExecutor {
    * console.log(`Execution took ${result.executionTime}ms using ${result.executionMethod}`)
    * ```
    */
-  async executeAgent(params: ExecutionParams): Promise<AgentExecutionResult> {
+  async executeAgent(
+    params: ExecutionParams,
+    overrides?: ExecutionOverrides
+  ): Promise<AgentExecutionResult> {
     // Input validation
     if (!params?.agent || !params.prompt) {
       const error = 'Invalid execution parameters: agent and prompt are required'
@@ -233,12 +265,22 @@ export class AgentExecutor {
     const startTime = Date.now()
     const requestId = this.generateRequestId()
 
+    // Resolve per-call effective values. `??` is used so that a caller passing
+    // `{ timeoutMs: undefined }` (e.g. mocks bypassing TS) still falls back to
+    // the server-wide config rather than corrupting it.
+    const effectiveTimeout = overrides?.timeoutMs ?? this.config.executionTimeout
+    const effectivePermission = overrides?.permission ?? this.config.permission
+
     this.logger.info('Starting agent execution', {
       requestId,
       agent: params.agent,
       promptLength: params.prompt.length,
       cwd: params.cwd,
       extraArgs: params.extra_args?.length || 0,
+      timeoutMs: effectiveTimeout,
+      permission: effectivePermission,
+      timeoutOverridden: overrides?.timeoutMs !== undefined,
+      permissionOverridden: overrides?.permission !== undefined,
     })
 
     try {
@@ -248,7 +290,7 @@ export class AgentExecutor {
       // Use spawn method for proper TTY handling
 
       // Execute using spawn for proper TTY handling
-      const result = await this.executeWithSpawn(params)
+      const result = await this.executeWithSpawn(params, effectiveTimeout, effectivePermission)
 
       const executionTime = Date.now() - startTime
 
@@ -305,7 +347,10 @@ export class AgentExecutor {
    *
    * @private
    */
-  private buildCommandArgs(params: ExecutionParams): {
+  private buildCommandArgs(
+    params: ExecutionParams,
+    permission: AgentPermission
+  ): {
     command: string
     args: string[]
     envOverrides: Record<string, string>
@@ -314,13 +359,13 @@ export class AgentExecutor {
 
     switch (this.config.agentType) {
       case 'codex':
-        return this.buildCodexArgs(params, envOverrides)
+        return this.buildCodexArgs(params, envOverrides, permission)
       case 'claude':
-        return this.buildClaudeArgs(params, envOverrides)
+        return this.buildClaudeArgs(params, envOverrides, permission)
       case 'gemini':
-        return this.buildGeminiArgs(params, envOverrides)
+        return this.buildGeminiArgs(params, envOverrides, permission)
       case 'cursor':
-        return this.buildCursorArgs(params, envOverrides)
+        return this.buildCursorArgs(params, envOverrides, permission)
     }
   }
 
@@ -347,15 +392,16 @@ export class AgentExecutor {
     return env
   }
 
-  private permissionFlags(): readonly string[] {
-    return PERMISSION_FLAGS[this.config.agentType][this.config.permission]
+  private permissionFlags(permission: AgentPermission): readonly string[] {
+    return PERMISSION_FLAGS[this.config.agentType][permission]
   }
 
   private buildCodexArgs(
     params: ExecutionParams,
-    envOverrides: Record<string, string>
+    envOverrides: Record<string, string>,
+    permission: AgentPermission
   ): { command: string; args: string[]; envOverrides: Record<string, string> } {
-    const perm = this.permissionFlags()
+    const perm = this.permissionFlags(permission)
     // System context is concatenated into the user prompt rather than injected
     // via `-c model_instructions_file=...`: that flag fully replaces codex's
     // default system prompt, which removed the built-in tool-use guidance and
@@ -368,9 +414,10 @@ export class AgentExecutor {
 
   private buildClaudeArgs(
     params: ExecutionParams,
-    envOverrides: Record<string, string>
+    envOverrides: Record<string, string>,
+    permission: AgentPermission
   ): { command: string; args: string[]; envOverrides: Record<string, string> } {
-    const perm = this.permissionFlags()
+    const perm = this.permissionFlags(permission)
     const cwd = params.cwd || process.cwd()
     const systemPrompt = `cwd: ${cwd}\n\n${params.agent}`
     const args: string[] = [
@@ -391,9 +438,10 @@ export class AgentExecutor {
 
   private buildGeminiArgs(
     params: ExecutionParams,
-    envOverrides: Record<string, string>
+    envOverrides: Record<string, string>,
+    permission: AgentPermission
   ): { command: string; args: string[]; envOverrides: Record<string, string> } {
-    const perm = this.permissionFlags()
+    const perm = this.permissionFlags(permission)
     // --skip-trust is unconditional: headless runs in untrusted folders are
     // refused without it (Gemini downgrades to interactive prompts which
     // deadlock here since we have no stdin).
@@ -412,9 +460,10 @@ export class AgentExecutor {
 
   private buildCursorArgs(
     params: ExecutionParams,
-    envOverrides: Record<string, string>
+    envOverrides: Record<string, string>,
+    permission: AgentPermission
   ): { command: string; args: string[]; envOverrides: Record<string, string> } {
-    const perm = this.permissionFlags()
+    const perm = this.permissionFlags(permission)
     const formattedPrompt = `[System Context]\n${params.agent}\n\n[User Prompt]\n${params.prompt}`
     const args = [...perm, '--output-format', 'json', '-p', formattedPrompt]
     const env: Record<string, string> = { ...envOverrides }
@@ -431,7 +480,11 @@ export class AgentExecutor {
    * @param params - Execution parameters
    * @returns Promise resolving to execution result
    */
-  private async executeWithSpawn(params: ExecutionParams): Promise<{
+  private async executeWithSpawn(
+    params: ExecutionParams,
+    timeoutMs: number,
+    permission: AgentPermission
+  ): Promise<{
     stdout: string
     stderr: string
     exitCode: number
@@ -440,7 +493,7 @@ export class AgentExecutor {
   }> {
     return new Promise((resolve) => {
       // Build command, args, and env based on agent type with system prompt separation
-      const { command, args, envOverrides } = this.buildCommandArgs(params)
+      const { command, args, envOverrides } = this.buildCommandArgs(params, permission)
 
       // Build environment variables for spawn
       const spawnEnv: NodeJS.ProcessEnv = { ...process.env, ...envOverrides }
@@ -467,7 +520,7 @@ export class AgentExecutor {
       // No need to handle stdin as it's set to 'ignore'
       const executionTimeout = setTimeout(() => {
         this.logger.warn('Execution timeout reached', {
-          timeout: this.config.executionTimeout,
+          timeout: timeoutMs,
         })
         childProcess.kill('SIGTERM')
 
@@ -475,12 +528,12 @@ export class AgentExecutor {
         const result = streamProcessor.getResult()
         resolve({
           stdout: result ? JSON.stringify(result) : stdout,
-          stderr: stderr || `Execution timeout: ${this.config.executionTimeout}ms`,
+          stderr: stderr || `Execution timeout: ${timeoutMs}ms`,
           exitCode: 124, // Standard timeout exit code
           hasResult: result !== null,
           resultJson: result !== null ? result : undefined,
         })
-      }, this.config.executionTimeout)
+      }, timeoutMs)
 
       // Handle stdout stream with simplified processing
       childProcess.stdout?.on('data', (data: Buffer) => {

--- a/src/execution/__tests__/AgentExecutor.test.ts
+++ b/src/execution/__tests__/AgentExecutor.test.ts
@@ -663,6 +663,102 @@ describe('AgentExecutor', () => {
     })
   })
 
+  describe('per-call execution overrides', () => {
+    // These tests anchor the contract that overrides apply to the current
+    // call only. Regressions here would let a single MCP request silently
+    // mutate server-wide defaults established at startup.
+    it.each([
+      // For each agent type, swapping the permission via overrides must
+      // change the head of argv to match that permission's flags. This also
+      // covers AC: executor-mapping (cursor, claude, gemini, codex) under
+      // per-call overrides.
+      { agent: 'codex' as const, perm: 'read-only' as const, expected: ['-s', 'read-only'] },
+      {
+        agent: 'codex' as const,
+        perm: 'yolo' as const,
+        expected: ['--dangerously-bypass-approvals-and-sandbox'],
+      },
+      {
+        agent: 'claude' as const,
+        perm: 'read-only' as const,
+        expected: ['--permission-mode', 'plan'],
+      },
+      {
+        agent: 'claude' as const,
+        perm: 'yolo' as const,
+        expected: ['--dangerously-skip-permissions'],
+      },
+      {
+        agent: 'gemini' as const,
+        perm: 'read-only' as const,
+        expected: ['--approval-mode', 'plan'],
+      },
+      { agent: 'gemini' as const, perm: 'yolo' as const, expected: ['-y'] },
+      { agent: 'cursor' as const, perm: 'read-only' as const, expected: ['--mode', 'plan'] },
+      { agent: 'cursor' as const, perm: 'yolo' as const, expected: ['-f', '--trust'] },
+    ])('per-call permission override applies $expected for $agent', async ({
+      agent,
+      perm,
+      expected,
+    }) => {
+      // Server-wide config defaults to safe-edit; the override must win.
+      const executor = new AgentExecutor(createExecutionConfig(agent))
+
+      await executor.executeAgent(
+        { agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' },
+        { permission: perm }
+      )
+
+      const args = mockSpawn.mock.calls[0][1] as string[]
+      expect(args.slice(0, expected.length)).toEqual(expected)
+    })
+
+    it('subsequent call without overrides reverts to server-wide permission default', async () => {
+      const executor = new AgentExecutor(createExecutionConfig('claude'))
+
+      // Override on call 1.
+      await executor.executeAgent({ agent: 'a', prompt: 'p', cwd: '/tmp' }, { permission: 'yolo' })
+      // No override on call 2 — must revert to safe-edit (the configured default).
+      await executor.executeAgent({ agent: 'a', prompt: 'p', cwd: '/tmp' })
+
+      const firstArgs = mockSpawn.mock.calls[0][1] as string[]
+      const secondArgs = mockSpawn.mock.calls[1][1] as string[]
+      expect(firstArgs.slice(0, 1)).toEqual(['--dangerously-skip-permissions'])
+      expect(secondArgs.slice(0, 2)).toEqual(['--permission-mode', 'acceptEdits'])
+    })
+
+    it('per-call timeoutMs override drives the spawn timeout for that call only', async () => {
+      mockSpawn.mockImplementationOnce(
+        () => createMockProcess({ noClose: true }) // never closes; override timeout fires
+      )
+
+      const executor = new AgentExecutor(
+        createExecutionConfig('cursor', { executionTimeout: 60_000 })
+      )
+
+      const result = await executor.executeAgent(
+        { agent: 'a', prompt: 'p', cwd: '/tmp' },
+        { timeoutMs: 50 } // far smaller than server-wide 60s
+      )
+
+      // Override took effect: process timed out at 50ms with the override
+      // value reflected in the timeout error message.
+      expect(result.exitCode).toBe(124)
+      expect(result.stderr).toContain('Execution timeout: 50ms')
+    })
+
+    it('omitting overrides falls back to the server-wide executionTimeout', async () => {
+      mockSpawn.mockImplementationOnce(() => createMockProcess({ noClose: true }))
+
+      const executor = new AgentExecutor(createExecutionConfig('cursor', { executionTimeout: 75 }))
+
+      const result = await executor.executeAgent({ agent: 'a', prompt: 'p', cwd: '/tmp' })
+
+      expect(result.exitCode).toBe(124)
+      expect(result.stderr).toContain('Execution timeout: 75ms')
+    })
+  })
+
   describe('SIGTERM and partial results', () => {
     it('should handle SIGTERM (exit code 143) as normal when hasResult is true', async () => {
       mockSpawn.mockImplementationOnce(() =>

--- a/src/tools/RunAgentTool.ts
+++ b/src/tools/RunAgentTool.ts
@@ -8,7 +8,15 @@
 
 import { randomUUID } from 'node:crypto'
 import type { AgentManager } from '../agents/AgentManager.js'
-import type { AgentExecutionResult, AgentExecutor } from '../execution/AgentExecutor.js'
+import {
+  AGENT_PERMISSIONS,
+  type AgentExecutionResult,
+  type AgentExecutor,
+  type AgentPermission,
+  type ExecutionOverrides,
+  isAgentPermission,
+  MAX_PER_CALL_TIMEOUT_MS,
+} from '../execution/AgentExecutor.js'
 import { formatSessionHistory } from '../session/SessionHistoryFormatter.js'
 import type { SessionManager } from '../session/SessionManager.js'
 import type { AgentDefinition } from '../types/AgentDefinition.js'
@@ -80,6 +88,17 @@ interface RunAgentInputSchema {
       type: 'string'
       description: string
     }
+    timeout_ms: {
+      type: 'integer'
+      minimum: number
+      maximum: number
+      description: string
+    }
+    permission: {
+      type: 'string'
+      enum: readonly AgentPermission[]
+      description: string
+    }
   }
   required: string[]
 }
@@ -99,6 +118,26 @@ interface RunAgentParams {
    * Must be alphanumeric with hyphens and underscores only (max 100 characters).
    */
   session_id?: string | undefined
+  /**
+   * Per-call execution timeout override in milliseconds (optional).
+   *
+   * Affects only the current run; the server-wide EXECUTION_TIMEOUT_MS default
+   * remains unchanged. Must be a positive integer ≤ MAX_PER_CALL_TIMEOUT_MS.
+   *
+   * Treated as an execution-only control: it is not persisted to the session
+   * payload and is not replayed on continuation calls.
+   */
+  timeout_ms?: number | undefined
+  /**
+   * Per-call approval/sandbox level override (optional).
+   *
+   * Affects only the current run; the server-wide AGENT_PERMISSION default
+   * remains unchanged. Must be one of the {@link AgentPermission} values.
+   *
+   * Treated as an execution-only control: it is not persisted to the session
+   * payload and is not replayed on continuation calls.
+   */
+  permission?: AgentPermission | undefined
 }
 
 /**
@@ -141,6 +180,17 @@ export class RunAgentTool {
         type: 'string',
         description:
           'Session ID for continuing previous conversation context (optional). If omitted, a new session will be auto-generated and returned in response metadata. Reuse the returned session_id in subsequent calls to maintain context continuity.',
+      },
+      timeout_ms: {
+        type: 'integer',
+        minimum: 1,
+        maximum: MAX_PER_CALL_TIMEOUT_MS,
+        description: `Per-call execution timeout override in milliseconds (optional). Must be a positive integer between 1 and ${MAX_PER_CALL_TIMEOUT_MS} (10 minutes). Applies only to this call; the server-wide EXECUTION_TIMEOUT_MS default is used when omitted. This value is execution-only and is never persisted in the session history or replayed on continuation calls.`,
+      },
+      permission: {
+        type: 'string',
+        enum: AGENT_PERMISSIONS,
+        description: `Per-call approval/sandbox level override (optional). One of: ${AGENT_PERMISSIONS.join(', ')}. Applies only to this call; the server-wide AGENT_PERMISSION default is used when omitted. This value is execution-only and is never persisted in the session history or replayed on continuation calls.`,
       },
     },
     required: ['agent', 'prompt', 'cwd'],
@@ -282,8 +332,20 @@ export class RunAgentTool {
 
         // Report progress: Executing agent
 
+        // Build per-call execution overrides. These are deliberately scoped to
+        // this call only and never written into ExecutionParams or the saved
+        // session payload, so subsequent calls (including continuation calls
+        // with the same session_id) revert to the server-wide defaults.
+        const executionOverrides: ExecutionOverrides = {}
+        if (validatedParams.timeout_ms !== undefined) {
+          executionOverrides.timeoutMs = validatedParams.timeout_ms
+        }
+        if (validatedParams.permission !== undefined) {
+          executionOverrides.permission = validatedParams.permission
+        }
+
         // Execute agent (this has its own timeout: MCP -> AI)
-        const result = await this.agentExecutor.executeAgent(executionParams)
+        const result = await this.agentExecutor.executeAgent(executionParams, executionOverrides)
 
         // Report progress: Execution completed
 
@@ -465,6 +527,38 @@ export class RunAgentTool {
       }
     }
 
+    // Validate optional timeout_ms parameter (per-call override).
+    // The intent is execution-only: positive integer milliseconds, no zero
+    // (would deadlock immediately), no negative (nonsensical), no over the
+    // documented ceiling (matches MAX_PER_CALL_TIMEOUT_MS = 10 minutes).
+    if (p['timeout_ms'] !== undefined) {
+      const timeoutMs = p['timeout_ms']
+      if (
+        typeof timeoutMs !== 'number' ||
+        !Number.isInteger(timeoutMs) ||
+        !Number.isFinite(timeoutMs) ||
+        timeoutMs <= 0
+      ) {
+        throw new Error('Invalid timeout_ms parameter: must be a positive integer (milliseconds)')
+      }
+      if (timeoutMs > MAX_PER_CALL_TIMEOUT_MS) {
+        throw new Error(
+          `Invalid timeout_ms parameter: must be ≤ ${MAX_PER_CALL_TIMEOUT_MS} (10 minutes)`
+        )
+      }
+    }
+
+    // Validate optional permission parameter (per-call override).
+    // Accepts only the documented AgentPermission values. Anything else
+    // would silently fall back to defaults and surprise the caller.
+    if (p['permission'] !== undefined) {
+      if (typeof p['permission'] !== 'string' || !isAgentPermission(p['permission'])) {
+        throw new Error(
+          `Invalid permission parameter: must be one of ${AGENT_PERMISSIONS.join(', ')}`
+        )
+      }
+    }
+
     // Validate optional session_id parameter
     if (p['session_id'] !== undefined) {
       if (typeof p['session_id'] !== 'string') {
@@ -494,6 +588,8 @@ export class RunAgentTool {
       cwd: cwd,
       extra_args: p['extra_args'] as string[] | undefined,
       session_id: p['session_id'] as string | undefined,
+      timeout_ms: p['timeout_ms'] as number | undefined,
+      permission: p['permission'] as AgentPermission | undefined,
     }
   }
 


### PR DESCRIPTION
## Goal

Add per-call timeout and permission controls to the run_agent MCP tool while preserving session history as prompt-only conversation state.

## Acceptance Criteria

- `AC1` run_agent input schema exposes optional timeout_ms and permission while preserving existing agent, prompt, cwd, session_id, and extra_args compatibility.
  - Verification: Inspect src/tools/RunAgentTool.ts schema and focused tests for additive schema fields and backwards-compatible minimal calls.
  - Status: satisfied
- `AC2` timeout_ms accepts only positive integer values within a documented upper bound; when omitted, existing EXECUTION_TIMEOUT_MS/default behavior is used.
  - Verification: Focused validation tests cover valid timeout, non-integer/negative/zero/too-large timeout, and default fallback.
  - Status: satisfied
- `AC3` permission accepts only the existing AgentPermission values read-only, safe-edit, and yolo; when omitted, existing AGENT_PERMISSION/default behavior is used.
  - Verification: Focused validation and execution tests cover valid permissions, invalid permissions, and default fallback.
  - Status: satisfied
- `AC4` Per-call timeout_ms and permission affect only the current executeAgent call and never mutate server-wide execution config.
  - Verification: Tests execute multiple calls against one RunAgentTool/AgentExecutor setup and verify later calls use default config after an override call.
  - Status: satisfied
- `AC5` Session persistence treats timeout_ms and permission as execution-only controls; saved session requests and continuation prompts must not persist or replay them.
  - Verification: Tests inspect the saved session payload/history and verify a later call with the same session_id but omitted controls does not inherit the previous timeout_ms or permission.
  - Status: satisfied
- `AC6` Invalid timeout_ms or permission inputs return MCP error responses and do not spawn an agent process or save a session entry.
  - Verification: RunAgentTool tests spy on executeAgent or the spawn boundary and session save boundary, asserting invalid inputs stop before execution and persistence.
  - Status: satisfied
- `AC7` Documentation and tests are updated, and build, check, and test commands pass.
  - Verification: README documents the execution-only nature of timeout_ms and permission; npm run build, npm run check, and npm test pass.
  - Status: satisfied

## Final Verification

- `npm run check:deps`: passed
- `npm run build`: passed
- `npm test`: passed
- `npm run check`: passed

## Key Decisions

- `claude-decision-1` What upper bound should timeout_ms enforce? -> MAX_PER_CALL_TIMEOUT_MS = 600000 (10 minutes), exposed as a named export and used both in the JSON schema (maximum) and in runtime validation.
  - Rationale: README and existing ServerConfig integration tests already document EXECUTION_TIMEOUT_MS max of 10 minutes; mirroring that ceiling for per-call overrides keeps a single MCP request from running longer than the published server-wide cap.
  - Reversibility: high
- `claude-decision-2` Where should per-call overrides live in the type system? -> Introduced a new ExecutionOverrides interface as a separate second argument to AgentExecutor.executeAgent rather than extending ExecutionParams.
  - Rationale: ExecutionParams mirrors the SessionEntry.request shape that gets persisted; mixing execution-only controls into it would risk accidental persistence (AC5). A separate overrides parameter makes the per-call vs. persistent boundary explicit at the type level.
  - Reversibility: medium
