### PR TITLE
chore(ci): bump pinned GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ env.NODE_VERSION_DEFAULT }}
         cache: 'npm'
@@ -45,10 +45,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ env.NODE_VERSION_DEFAULT }}
         cache: 'npm'
@@ -68,10 +68,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ env.NODE_VERSION_DEFAULT }}
         cache: 'npm'
@@ -105,10 +105,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ env.NODE_VERSION_DEFAULT }}
         cache: 'npm'
@@ -122,7 +122,7 @@ jobs:
 
     - name: Upload quality report
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: quality-report
         path: tmp/quality-report.json


### PR DESCRIPTION
## Summary

The GitHub Actions pinned in `ci.yml` were several major versions behind. This updates all SHA-pinned actions to their latest stable releases.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4.3.1 | v6.0.3 |
| `actions/setup-node` | v4.4.0 | v6.4.0 |
| `actions/upload-artifact` | v4.6.2 | v7.0.1 |

All actions are pinned by commit SHA (verified against the corresponding version tags via the GitHub API). The version comments are updated accordingly.

## Notes

- `actions/upload-artifact` jumps v4 → v7 (three major versions). v4 introduced a reworked implementation with breaking changes (no appending to an existing artifact of the same name, immediate availability). This workflow performs a single upload, so the impact should be minimal — but CI on this PR exercises the change directly.
- `actions/checkout` and `actions/setup-node` major bumps are primarily driven by Node runtime upgrades and should run fine on `ubuntu-latest`.

## Verification

CI runs this workflow itself, so a green check confirms the updated actions work end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)