### PR TITLE
chore: normalize npm bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/shinpr/sub-agents-mcp#readme",
   "bin": {
-    "sub-agents-mcp": "./dist/index.js"
+    "sub-agents-mcp": "dist/index.js"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
## Summary

- Normalize the npm `bin` path from `./dist/index.js` to `dist/index.js`.
- This removes the npm publish auto-correction warning before publishing `0.9.0`.

## Validation

- `npm publish --dry-run`
- `npm run check` (pre-push hook)
- `npm run build` (pre-push hook)
