### PR TITLE
Add Grok Build backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Bring Claude Code–style sub-agents to any MCP-compatible tool.
 
-This MCP server lets you define task-specific AI agents (like "test-writer" or "code-reviewer") in markdown files, and execute them via Cursor CLI, Claude Code, Codex, or Gemini CLI backends.
+This MCP server lets you define task-specific AI agents (like "test-writer" or "code-reviewer") in markdown files, and execute them via Cursor CLI, Claude Code, Codex, Gemini CLI, GLM, or Grok Build backends.
 
 ## Why?
 
@@ -14,7 +14,7 @@ Claude Code offers powerful sub-agent workflows—but they're limited to its own
 **Concrete benefits:**
 - Define reusable agents once, use them across multiple tools
 - Share agent definitions within teams regardless of IDE choice
-- Leverage Cursor CLI, Claude Code, Codex, or Gemini CLI capabilities from any MCP client
+- Leverage Cursor CLI, Claude Code, Codex, Gemini CLI, GLM, or Grok Build capabilities from any MCP client
 
 → [Read the full story](https://dev.to/shinpr/bringing-claude-codes-sub-agents-to-any-mcp-compatible-tool-1hb9)
 
@@ -52,6 +52,7 @@ Choose **sub-agents-mcp** for production use with reliability features. Choose *
   - `codex` CLI (from Codex)
   - `gemini` CLI (from Gemini CLI — requires `GEMINI_API_KEY`)
   - `glm` backend (uses the Claude Code `claude` CLI with a Z.ai token)
+  - `grok` CLI (from Grok Build)
 - An MCP-compatible tool (Cursor IDE, Claude Desktop, Windsurf, etc.)
 
 ## Quick Start
@@ -126,6 +127,12 @@ curl -fsSL https://claude.ai/install.sh | bash
 
 Set `AGENT_TYPE` to `glm` and add `CLI_API_KEY` to the MCP server environment in your MCP client configuration. Because MCP servers are long-running processes, restart or reconnect the MCP server after changing `CLI_API_KEY`.
 
+**For Grok Build users:**
+```bash
+# Install Grok Build
+curl -fsSL https://x.ai/cli/install.sh | bash
+```
+
 ### 3. Configure MCP
 
 Add this to your MCP configuration file:
@@ -141,7 +148,7 @@ Add this to your MCP configuration file:
       "args": ["-y", "sub-agents-mcp"],
       "env": {
         "AGENTS_DIR": "/absolute/path/to/your/agents-folder",
-        "AGENT_TYPE": "cursor"  // or "claude", "codex", "gemini", or "glm"
+        "AGENT_TYPE": "cursor"  // or "claude", "codex", "gemini", "glm", or "grok"
       }
     }
   }
@@ -174,6 +181,9 @@ Sub-agents may fail to execute shell commands with permission errors. This happe
 
    # For Gemini CLI users
    gemini
+
+   # For Grok Build users
+   grok
    ```
 
 2. When prompted to allow commands (e.g., "Add Shell(cd), Shell(make) to allowlist?"), approve them
@@ -310,17 +320,18 @@ Which execution engine to use:
 - `"gemini"` - uses `gemini` CLI
 - `"codex"` - uses `codex` CLI (OpenAI Codex)
 - `"glm"` - uses the Claude Code `claude` CLI against GLM's Z.ai endpoint
+- `"grok"` - uses `grok` CLI (Grok Build)
 
 ### Optional Settings
 
 **`AGENT_PERMISSION`**
 Approval/sandbox level the sub-agent runs with. Default: `"safe-edit"`.
 
-- `"read-only"` — investigation/review only, no edits or shell writes (codex `-s read-only` / claude+glm `--permission-mode plan` / gemini `--approval-mode plan` / cursor `--mode plan`)
-- `"safe-edit"` — auto-approve edits and suppress prompts (codex `-s workspace-write` + `approval_policy=never` / claude+glm `--permission-mode acceptEdits` / gemini `--approval-mode auto_edit` / cursor `--trust`)
+- `"read-only"` — investigation/review only, no edits or shell writes (codex `-s read-only` / claude+glm `--permission-mode plan` / gemini `--approval-mode plan` / cursor `--mode plan` / grok `--permission-mode dontAsk`)
+- `"safe-edit"` — auto-approve edits and suppress prompts (codex `-s workspace-write` + `approval_policy=never` / claude+glm `--permission-mode acceptEdits` / gemini `--approval-mode auto_edit` / cursor `--trust` / grok `--permission-mode auto`)
 - `"yolo"` — bypass all approvals and sandboxing. Use with care.
 
-Sub-agents have no stdin, so any approval prompt would deadlock the run. The default `safe-edit` removes prompts; the depth of sandboxing depends on the CLI — codex enforces a `workspace-write` sandbox, while claude / glm / gemini / cursor only auto-approve and do not jail edits to the workspace. If you need strict containment, use `read-only` and run privileged steps separately.
+Sub-agents have no stdin, so any approval prompt would deadlock the run. The default `safe-edit` removes prompts; the depth of sandboxing depends on the CLI — codex enforces a `workspace-write` sandbox, while claude / glm / gemini / cursor / grok only auto-approve and do not jail edits to the workspace. Grok runs also pass `--always-approve` so headless runs do not cancel while waiting for user approval; `AGENT_PERMISSION` still selects Grok's permission mode. If you need strict containment, use `read-only` and run privileged steps separately.
 
 **`CLI_API_KEY`**
 Z.ai API token for `AGENT_TYPE=glm`. It is forwarded to the Claude Code binary as `ANTHROPIC_AUTH_TOKEN` and never passed as a CLI argument. If you add or change it in your MCP client configuration, restart or reconnect the MCP server so the running process receives the new environment.
@@ -335,7 +346,7 @@ Each CLI normally reads settings from project-level directories (`.claude/`, `.c
 
 Applied to: `claude`, `cursor`, `codex`.
 
-Note: Gemini CLI does not support custom settings paths, so this option has no effect when `AGENT_TYPE` is `gemini`. The `glm` backend also ignores this setting to avoid mixing Claude settings into the Z.ai-backed subprocess.
+Note: Gemini CLI and Grok Build do not support custom settings paths, so this option has no effect when `AGENT_TYPE` is `gemini` or `grok`. The `glm` backend also ignores this setting to avoid mixing Claude settings into the Z.ai-backed subprocess.
 
 Example with custom settings:
 ```json
@@ -449,6 +460,9 @@ Make sure the CLI is properly installed and accessible.
 **If using GLM (Z.ai):**
 Make sure the Claude Code `claude` CLI is installed, then set `CLI_API_KEY` to your Z.ai token in the MCP server environment. Restart or reconnect the MCP server after changing MCP environment variables.
 
+**If using Grok Build:**
+Make sure the `grok` CLI is installed and accessible.
+
 ### Agent not found
 
 Check that:
@@ -458,7 +472,7 @@ Check that:
 
 ### Other execution errors
 
-1. Verify `AGENT_TYPE` is set correctly (`cursor`, `claude`, `gemini`, `codex`, or `glm`)
+1. Verify `AGENT_TYPE` is set correctly (`cursor`, `claude`, `gemini`, `codex`, `glm`, or `grok`)
 2. Ensure your chosen CLI tool is installed and accessible
 3. Double-check that all environment variables are set in the MCP config
 
@@ -510,14 +524,14 @@ The startup overhead is an intentional trade-off: the system favors clarity and 
 
 ## How It Works
 
-This MCP server acts as a bridge between your AI tool and a supported execution engine (Cursor CLI, Claude Code, Gemini CLI, Codex, or GLM via Z.ai).
+This MCP server acts as a bridge between your AI tool and a supported execution engine (Cursor CLI, Claude Code, Gemini CLI, Codex, GLM via Z.ai, or Grok Build).
 
 **The flow:**
 
 1. You configure the MCP server in your client (Cursor, Claude Desktop, etc.)
 2. The client automatically launches `sub-agents-mcp` as a background process when it starts
 3. When your main AI assistant needs a sub-agent, it makes an MCP tool call
-4. The MCP server reads the agent definition (markdown file) and invokes the selected CLI (`cursor-agent`, `claude`, `gemini`, `codex`, or `glm` via the `claude` binary)
+4. The MCP server reads the agent definition (markdown file) and invokes the selected CLI (`cursor-agent`, `claude`, `gemini`, `codex`, `glm` via the `claude` binary, or `grok`)
 5. The execution engine runs the agent and streams results back through the MCP server
 6. Your main assistant receives the results and continues working
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-agents-mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-agents-mcp",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "sub-agents-mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "mcpName": "io.github.shinpr/sub-agents-mcp",
-  "description": "MCP server for delegating tasks to specialized AI assistants in Cursor, Claude Code, Codex, Gemini, and GLM",
+  "description": "MCP server for delegating tasks to specialized AI assistants in Cursor, Claude Code, Codex, Gemini, GLM, and Grok",
   "type": "module",
   "main": "dist/index.js",
   "files": [
@@ -26,6 +26,7 @@
     "codex",
     "glm",
     "z.ai",
+    "grok",
     "llm",
     "cli",
     "agent-orchestration"

--- a/server.json
+++ b/server.json
@@ -1,20 +1,20 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shinpr/sub-agents-mcp",
-  "description": "MCP server for AI sub-agent delegation across Cursor, Claude, Codex, Gemini, and GLM",
+  "description": "MCP server for AI sub-agent delegation across Cursor, Claude, Codex, Gemini, GLM, and Grok",
   "vendor": "Shinsuke Kagawa",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/shinpr/sub-agents-mcp",
     "source": "github"
   },
-  "version": "0.9.0",
+  "version": "0.10.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "sub-agents-mcp",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
         },
         {
           "name": "AGENT_TYPE",
-          "description": "Type of AI CLI to use: 'cursor', 'claude', 'gemini', 'codex', or 'glm'",
+          "description": "Type of AI CLI to use: 'cursor', 'claude', 'gemini', 'codex', 'glm', or 'grok'",
           "isRequired": true,
           "format": "string",
           "isSecret": false
@@ -84,7 +84,7 @@
         },
         {
           "name": "AGENTS_SETTINGS_PATH",
-          "description": "Path to CLI settings file/directory. Claude: --settings arg, Cursor: CURSOR_CONFIG_DIR, Codex: CODEX_HOME. Gemini not supported.",
+          "description": "Path to CLI settings file/directory. Claude: --settings arg, Cursor: CURSOR_CONFIG_DIR, Codex: CODEX_HOME. Gemini/Grok not supported.",
           "isRequired": false,
           "format": "string",
           "isSecret": false
@@ -118,6 +118,7 @@
     "codex",
     "glm",
     "z.ai",
+    "grok",
     "llm",
     "cli",
     "agent-orchestration"

--- a/src/__tests__/integration/RunAgentTool.integration.test.ts
+++ b/src/__tests__/integration/RunAgentTool.integration.test.ts
@@ -612,6 +612,47 @@ describe('RunAgentTool', () => {
         exit_code: 0,
       })
     })
+
+    it('should preserve partial status from agent result JSON even with exit code 0', async () => {
+      const params = {
+        agent: 'partial-agent',
+        prompt: 'Test partial completion',
+        cwd: process.cwd(),
+      }
+
+      const mockResult = {
+        stdout: JSON.stringify({
+          type: 'result',
+          result: 'Progress only',
+          status: 'partial',
+          stop_reason: 'Cancelled',
+        }),
+        stderr: '',
+        exitCode: 0,
+        executionTime: 100,
+        hasResult: true,
+        resultJson: {
+          type: 'result',
+          result: 'Progress only',
+          status: 'partial',
+          stop_reason: 'Cancelled',
+        },
+      }
+
+      vi.spyOn(mockAgentExecutor, 'executeAgent').mockResolvedValue(mockResult)
+
+      const result = await runAgentTool.execute(params)
+      const textContent = result.content.find((c) => c.type === 'text')
+      const parsedContent = JSON.parse(textContent?.text || '{}')
+
+      expect(parsedContent.result).toBe('Progress only')
+      expect(parsedContent.exit_code).toBe(0)
+      expect(parsedContent.status).toBe('partial')
+      expect(result.structuredContent).toMatchObject({
+        status: 'partial',
+        exit_code: 0,
+      })
+    })
   })
 
   describe('session ID auto-generation', () => {

--- a/src/__tests__/integration/ServerConfig.integration.test.ts
+++ b/src/__tests__/integration/ServerConfig.integration.test.ts
@@ -49,6 +49,7 @@ describe('ServerConfig', () => {
     'gemini',
     'codex',
     'glm',
+    'grok',
   ] as const)('should accept AGENT_TYPE=%s', (agentType) => {
     vi.stubEnv('AGENTS_DIR', testAgentsDir)
     vi.stubEnv('AGENT_TYPE', agentType)

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -19,7 +19,7 @@ import { isLogLevel, LOG_LEVELS, type LogLevel } from '../utils/Logger.js'
  * - SERVER_NAME: Name identifier for the MCP server (default: 'sub-agents-mcp-server')
  * - SERVER_VERSION: Version of the MCP server (default: '1.0.0')
  * - AGENTS_DIR: Directory containing agent definition files (REQUIRED - must be absolute path)
- * - AGENT_TYPE: Type of agent to use ('cursor' | 'claude' | 'gemini' | 'codex' | 'glm') (default: 'cursor')
+ * - AGENT_TYPE: Type of agent to use ('cursor' | 'claude' | 'gemini' | 'codex' | 'glm' | 'grok') (default: 'cursor')
  * - AGENT_PERMISSION: Approval/sandbox level for sub-agents ('read-only' | 'safe-edit' | 'yolo') (default: 'safe-edit')
  * - LOG_LEVEL: Log level for server operations (default: 'info')
  * - SESSION_ENABLED: Enable session management functionality (default: false)
@@ -155,7 +155,7 @@ export class ServerConfig {
     // - Claude: passed as --settings argument
     // - Cursor: set as CURSOR_CONFIG_DIR environment variable
     // - Codex: set as CODEX_HOME environment variable
-    // - Gemini: not supported (upstream limitation)
+    // - Gemini/Grok: not supported (upstream limitation)
     this.agentsSettingsPath = process.env['AGENTS_SETTINGS_PATH'] || undefined
 
     // Cursor API key: prefer CURSOR_API_KEY, fall back to CLI_API_KEY for backward compatibility

--- a/src/execution/AgentExecutor.ts
+++ b/src/execution/AgentExecutor.ts
@@ -57,7 +57,7 @@ export interface ExecutionConfig {
 
   /**
    * Type of agent to use for execution.
-   * 'cursor', 'claude', 'gemini', 'codex', or 'glm'
+   * 'cursor', 'claude', 'gemini', 'codex', 'glm', or 'grok'
    */
   agentType: AgentType
 
@@ -110,7 +110,7 @@ const GLM_MISSING_API_KEY_ERROR =
  * Supported agent runtimes. Single source of truth for both runtime validation
  * (ServerConfig) and static typing.
  */
-export const AGENT_TYPES = ['cursor', 'claude', 'gemini', 'codex', 'glm'] as const
+export const AGENT_TYPES = ['cursor', 'claude', 'gemini', 'codex', 'glm', 'grok'] as const
 
 export type AgentType = (typeof AGENT_TYPES)[number]
 
@@ -172,6 +172,11 @@ const PERMISSION_FLAGS: Record<AgentType, Record<AgentPermission, readonly strin
     'read-only': ['--mode', 'plan'],
     'safe-edit': ['--trust'],
     yolo: ['-f', '--trust'],
+  },
+  grok: {
+    'read-only': ['--permission-mode', 'dontAsk'],
+    'safe-edit': ['--permission-mode', 'auto'],
+    yolo: ['--permission-mode', 'bypassPermissions'],
   },
 }
 
@@ -344,6 +349,8 @@ export class AgentExecutor {
         return this.buildGeminiArgs(params, envOverrides)
       case 'cursor':
         return this.buildCursorArgs(params, envOverrides)
+      case 'grok':
+        return this.buildGrokArgs(params, envOverrides)
     }
   }
 
@@ -366,6 +373,7 @@ export class AgentExecutor {
         break
       // claude: handled via --settings argv below
       // glm: uses the claude binary, but intentionally avoids Claude settings.
+      // grok: not supported (upstream limitation)
       // gemini: not supported (upstream limitation)
     }
     return env
@@ -373,6 +381,10 @@ export class AgentExecutor {
 
   private permissionFlags(): readonly string[] {
     return PERMISSION_FLAGS[this.config.agentType][this.config.permission]
+  }
+
+  private formatSystemUserPrompt(params: ExecutionParams): string {
+    return `[System Context]\n${params.agent}\n\n[User Prompt]\n${params.prompt}`
   }
 
   private buildCodexArgs(
@@ -385,7 +397,7 @@ export class AgentExecutor {
     // default system prompt, which removed the built-in tool-use guidance and
     // measurably increased exploration overhead and token usage in our tests.
     // Concatenation keeps codex's defaults intact and matches the cursor path.
-    const formattedPrompt = `[System Context]\n${params.agent}\n\n[User Prompt]\n${params.prompt}`
+    const formattedPrompt = this.formatSystemUserPrompt(params)
     const args = [...perm, 'exec', '--json', '--skip-git-repo-check', formattedPrompt]
     return { command: 'codex', args, envOverrides }
   }
@@ -464,7 +476,7 @@ export class AgentExecutor {
         envOverrides: { ...envOverrides, GEMINI_SYSTEM_MD: params.agentFilePath },
       }
     }
-    const formattedPrompt = `[System Context]\n${params.agent}\n\n[User Prompt]\n${params.prompt}`
+    const formattedPrompt = this.formatSystemUserPrompt(params)
     const args = [...perm, '--skip-trust', '--output-format', 'stream-json', '-p', formattedPrompt]
     return { command: 'gemini', args, envOverrides }
   }
@@ -474,13 +486,34 @@ export class AgentExecutor {
     envOverrides: EnvOverrides
   ): { command: string; args: string[]; envOverrides: EnvOverrides } {
     const perm = this.permissionFlags()
-    const formattedPrompt = `[System Context]\n${params.agent}\n\n[User Prompt]\n${params.prompt}`
+    const formattedPrompt = this.formatSystemUserPrompt(params)
     const args = [...perm, '--output-format', 'json', '-p', formattedPrompt]
     const env: EnvOverrides = { ...envOverrides }
     if (this.config.cursorApiKey) {
       env['CURSOR_API_KEY'] = this.config.cursorApiKey
     }
     return { command: 'cursor-agent', args, envOverrides: env }
+  }
+
+  private buildGrokArgs(
+    params: ExecutionParams,
+    envOverrides: EnvOverrides
+  ): { command: string; args: string[]; envOverrides: EnvOverrides } {
+    const perm = this.permissionFlags()
+    const cwd = params.cwd || process.cwd()
+    const formattedPrompt = this.formatSystemUserPrompt(params)
+    const args = [
+      ...perm,
+      '--cwd',
+      cwd,
+      '--output-format',
+      'json',
+      '--always-approve',
+      '--verbatim',
+      '-p',
+      formattedPrompt,
+    ]
+    return { command: 'grok', args, envOverrides }
   }
 
   private buildSpawnEnv(envOverrides: EnvOverrides): NodeJS.ProcessEnv {
@@ -589,7 +622,11 @@ export class AgentExecutor {
         clearTimeout(executionTimeout)
 
         // Get the final result JSON
-        const result = streamProcessor.getResult()
+        let result = streamProcessor.getResult()
+        if (result === null) {
+          streamProcessor.processCompleteOutput(stdout)
+          result = streamProcessor.getResult()
+        }
 
         resolve({
           stdout: result ? JSON.stringify(result) : stdout,

--- a/src/execution/StreamProcessor.ts
+++ b/src/execution/StreamProcessor.ts
@@ -1,12 +1,13 @@
 /**
  * StreamProcessor - Simplified stream processing for agent output
  *
- * Handles cursor, claude, gemini, and codex output in JSON format.
+ * Handles cursor, claude, gemini, codex, and grok output in JSON format.
  * - Cursor/Claude: Use --output-format json, return a single JSON with type: "result"
  * - Gemini: Uses --output-format stream-json, returns multiple JSON lines,
  *           assistant messages contain the response, type: "result" signals completion
  * - Codex: Uses --json flag with exec subcommand, returns stream of JSON events,
  *          agent_message items contain the response, turn.completed signals completion
+ * - Grok: Uses --output-format json, returns a complete JSON object after exit
  */
 export class StreamProcessor {
   private resultJson: unknown = null
@@ -109,6 +110,12 @@ export class StreamProcessor {
         return true // Processing complete
       }
 
+      const normalizedCompleteOutput = this.normalizeCompleteOutput(json)
+      if (normalizedCompleteOutput) {
+        this.resultJson = normalizedCompleteOutput
+        return true
+      }
+
       // For backwards compatibility: store first valid JSON if no type field
       // This handles any CLI that doesn't use the type field
       if (!('type' in json)) {
@@ -124,12 +131,72 @@ export class StreamProcessor {
   }
 
   /**
+   * Process a complete non-NDJSON payload after process exit.
+   *
+   * Grok's `--output-format json` can emit a pretty-printed JSON object, which
+   * cannot be parsed by the line-oriented stream path.
+   *
+   * @param output - Complete stdout captured from the agent process
+   * @returns true if processing is complete, false otherwise
+   */
+  processCompleteOutput(output: string): boolean {
+    if (this.resultJson !== null) {
+      return false
+    }
+
+    try {
+      const json = JSON.parse(output.trim()) as unknown
+      if (!this.isRecord(json)) {
+        return false
+      }
+
+      const normalizedCompleteOutput = this.normalizeCompleteOutput(json)
+      if (!normalizedCompleteOutput) {
+        return false
+      }
+
+      this.resultJson = normalizedCompleteOutput
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  private normalizeCompleteOutput(json: Record<string, unknown>): Record<string, unknown> | null {
+    if (typeof json['text'] !== 'string' || !('stopReason' in json)) {
+      return null
+    }
+
+    const result: Record<string, unknown> = {
+      type: 'result',
+      result: json['text'],
+      status: json['stopReason'] === 'EndTurn' ? 'success' : 'partial',
+    }
+
+    if (typeof json['stopReason'] === 'string') {
+      result['stop_reason'] = json['stopReason']
+    }
+    if (typeof json['sessionId'] === 'string') {
+      result['session_id'] = json['sessionId']
+    }
+    if (typeof json['requestId'] === 'string') {
+      result['request_id'] = json['requestId']
+    }
+
+    return result
+  }
+
+  /**
    * Type guard for Codex item structure
    * @param item - The item to check
    * @returns true if item is a valid Codex item object
    */
   private isCodexItem(item: unknown): item is Record<string, unknown> {
-    return typeof item === 'object' && item !== null
+    return this.isRecord(item)
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
   }
 
   /**

--- a/src/execution/__tests__/AgentExecutor.test.ts
+++ b/src/execution/__tests__/AgentExecutor.test.ts
@@ -107,12 +107,14 @@ describe('AgentExecutor', () => {
       const geminiConfig = createExecutionConfig('gemini')
       const codexConfig = createExecutionConfig('codex')
       const glmConfig = createExecutionConfig('glm')
+      const grokConfig = createExecutionConfig('grok')
 
       expect(cursorConfig.agentType).toBe('cursor')
       expect(claudeConfig.agentType).toBe('claude')
       expect(geminiConfig.agentType).toBe('gemini')
       expect(codexConfig.agentType).toBe('codex')
       expect(glmConfig.agentType).toBe('glm')
+      expect(grokConfig.agentType).toBe('grok')
     })
 
     it('should allow setting agentsSettingsPath', () => {
@@ -177,6 +179,14 @@ describe('AgentExecutor', () => {
       await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
 
       expect(mockSpawn).toHaveBeenCalledWith('claude', expect.any(Array), expect.any(Object))
+    })
+
+    it('should use grok command for grok type', async () => {
+      const executor = new AgentExecutor(createExecutionConfig('grok'))
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      expect(mockSpawn).toHaveBeenCalledWith('grok', expect.any(Array), expect.any(Object))
     })
   })
 
@@ -249,6 +259,22 @@ describe('AgentExecutor', () => {
       const spawnEnv = mockSpawn.mock.calls[0][2].env
       expect(spawnEnv['GEMINI_CONFIG_DIR']).toBeUndefined()
       expect(spawnEnv['GEMINI_HOME']).toBeUndefined()
+    })
+
+    it('should not modify env for grok when agentsSettingsPath is set', async () => {
+      const settingsPath = '/path/to/grok/settings'
+      const executor = new AgentExecutor(
+        createExecutionConfig('grok', {
+          agentsSettingsPath: settingsPath,
+        })
+      )
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      const args = mockSpawn.mock.calls[0][1] as string[]
+      const spawnEnv = mockSpawn.mock.calls[0][2].env
+      expect(args).not.toContain(settingsPath)
+      expect(Object.values(spawnEnv)).not.toContain(settingsPath)
     })
 
     it('should not pass --settings for claude when agentsSettingsPath is not set', async () => {
@@ -501,6 +527,20 @@ describe('AgentExecutor', () => {
       expect(promptArg).toContain('[User Prompt]')
       expect(promptArg).toContain('Test prompt')
     })
+
+    it('should concatenate for grok with both system context and user prompt', async () => {
+      const executor = new AgentExecutor(createExecutionConfig('grok'))
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      const args = mockSpawn.mock.calls[0][1] as string[]
+      const pIdx = args.indexOf('-p')
+      const promptArg = args[pIdx + 1]
+      expect(promptArg).toContain('[System Context]')
+      expect(promptArg).toContain('test-agent')
+      expect(promptArg).toContain('[User Prompt]')
+      expect(promptArg).toContain('Test prompt')
+    })
   })
 
   describe('executeAgent', () => {
@@ -562,6 +602,39 @@ describe('AgentExecutor', () => {
         expect.arrayContaining(['-p', expect.stringContaining('Generate detailed documentation')]),
         expect.any(Object)
       )
+    })
+
+    it('should parse grok pretty JSON output after process exit', async () => {
+      mockSpawn.mockImplementationOnce(() =>
+        createMockProcess({
+          stdoutData:
+            '{\n' +
+            '  "text": "Grok execution successful",\n' +
+            '  "stopReason": "EndTurn",\n' +
+            '  "sessionId": "session-123",\n' +
+            '  "requestId": "request-123"\n' +
+            '}\n',
+        })
+      )
+
+      const executor = new AgentExecutor(createExecutionConfig('grok'))
+
+      const result = await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Help me',
+        cwd: '/tmp',
+      })
+
+      expect(result.exitCode).toBe(0)
+      expect(result.hasResult).toBe(true)
+      expect(result.resultJson).toEqual({
+        type: 'result',
+        result: 'Grok execution successful',
+        status: 'success',
+        stop_reason: 'EndTurn',
+        session_id: 'session-123',
+        request_id: 'request-123',
+      })
     })
   })
 
@@ -643,6 +716,10 @@ describe('AgentExecutor', () => {
       { agent: 'cursor', perm: 'read-only', expected: ['--mode', 'plan'] },
       { agent: 'cursor', perm: 'safe-edit', expected: ['--trust'] },
       { agent: 'cursor', perm: 'yolo', expected: ['-f', '--trust'] },
+      // grok
+      { agent: 'grok', perm: 'read-only', expected: ['--permission-mode', 'dontAsk'] },
+      { agent: 'grok', perm: 'safe-edit', expected: ['--permission-mode', 'auto'] },
+      { agent: 'grok', perm: 'yolo', expected: ['--permission-mode', 'bypassPermissions'] },
     ]
 
     it.each(cases)('should prepend $expected for agent=$agent permission=$perm', async ({
@@ -718,8 +795,28 @@ describe('AgentExecutor', () => {
       expect(args).toContain('--skip-trust')
     })
 
+    it('should include required headless flags for grok read-only', async () => {
+      const executor = new AgentExecutor(createExecutionConfig('grok', { permission: 'read-only' }))
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      const args = mockSpawn.mock.calls[0][1] as string[]
+      expect(args).toEqual(
+        expect.arrayContaining([
+          '--permission-mode',
+          'dontAsk',
+          '--cwd',
+          '/tmp',
+          '--output-format',
+          'json',
+          '--always-approve',
+          '--verbatim',
+        ])
+      )
+    })
+
     it('should not leak codex-specific flags into other CLIs', async () => {
-      for (const agent of ['claude', 'gemini', 'cursor', 'glm'] as const) {
+      for (const agent of ['claude', 'gemini', 'cursor', 'glm', 'grok'] as const) {
         mockSpawn.mockClear()
         const executor = new AgentExecutor(
           createExecutionConfig(agent, { glmApiKey: 'zai-secret' })

--- a/src/execution/__tests__/StreamProcessor.test.ts
+++ b/src/execution/__tests__/StreamProcessor.test.ts
@@ -127,6 +127,21 @@ describe('StreamProcessor', () => {
       })
     })
 
+    it('should normalize single-line grok JSON output', () => {
+      const grokJson =
+        '{"text":"Grok output","stopReason":"EndTurn","sessionId":"session-123","requestId":"request-123"}'
+
+      expect(processor.processLine(grokJson)).toBe(true)
+      expect(processor.getResult()).toEqual({
+        type: 'result',
+        result: 'Grok output',
+        status: 'success',
+        stop_reason: 'EndTurn',
+        session_id: 'session-123',
+        request_id: 'request-123',
+      })
+    })
+
     it('should extract agent_message text from codex output stream', () => {
       // Given: A complete Codex output stream with reasoning and agent_message
       const codexOutputStream = [
@@ -220,6 +235,49 @@ describe('StreamProcessor', () => {
       expect(processor.processLine('{"incomplete": ')).toBe(false)
       // null is valid JSON but not an object with type field, so it's ignored
       expect(processor.processLine('null')).toBe(false)
+      expect(processor.getResult()).toBeNull()
+    })
+  })
+
+  describe('Complete output handling', () => {
+    it('should normalize pretty-printed grok JSON output after process exit', () => {
+      expect(
+        processor.processCompleteOutput(
+          '{\n' +
+            '  "text": "Grok output",\n' +
+            '  "stopReason": "EndTurn",\n' +
+            '  "sessionId": "session-123",\n' +
+            '  "requestId": "request-123"\n' +
+            '}'
+        )
+      ).toBe(true)
+
+      expect(processor.getResult()).toEqual({
+        type: 'result',
+        result: 'Grok output',
+        status: 'success',
+        stop_reason: 'EndTurn',
+        session_id: 'session-123',
+        request_id: 'request-123',
+      })
+    })
+
+    it('should mark grok non-EndTurn output as partial', () => {
+      expect(
+        processor.processCompleteOutput('{"text":"Progress only","stopReason":"Cancelled"}')
+      ).toBe(true)
+
+      expect(processor.getResult()).toEqual({
+        type: 'result',
+        result: 'Progress only',
+        status: 'partial',
+        stop_reason: 'Cancelled',
+      })
+    })
+
+    it('should ignore complete output when it is not grok JSON', () => {
+      expect(processor.processCompleteOutput('plain text output')).toBe(false)
+      expect(processor.processCompleteOutput('{"response":"legacy"}')).toBe(false)
       expect(processor.getResult()).toBeNull()
     })
   })

--- a/src/tools/RunAgentTool.ts
+++ b/src/tools/RunAgentTool.ts
@@ -582,6 +582,10 @@ export class RunAgentTool {
     return exitCode !== 0 && exitCode !== 143 && exitCode !== 124
   }
 
+  private isPartialResult(resultJson: unknown): boolean {
+    return this.isRecord(resultJson) && resultJson['status'] === 'partial'
+  }
+
   /**
    * Format agent execution response (ADR-0003)
    *
@@ -615,11 +619,13 @@ export class RunAgentTool {
     )
 
     // Determine detailed status
-    const isSuccess =
-      result.exitCode === 0 || // Normal completion
-      (result.exitCode === 143 && result.hasResult === true) // SIGTERM with result
+    const isPartialSuccess =
+      this.isPartialResult(result.resultJson) ||
+      (result.exitCode === 124 && result.hasResult === true) // Timeout with partial result
 
-    const isPartialSuccess = result.exitCode === 124 && result.hasResult === true // Timeout with partial result
+    const isSuccess =
+      (!isPartialSuccess && result.exitCode === 0) || // Normal completion
+      (!isPartialSuccess && result.exitCode === 143 && result.hasResult === true) // SIGTERM with result
 
     // Build response data structure (ADR-0003)
     // This object is used in both content[0].text and structuredContent


### PR DESCRIPTION
## Summary
- add Grok Build as a supported backend via AGENT_TYPE=grok
- map Grok permission modes and run headless executions with --always-approve to avoid approval-cancelled runs
- parse Grok --output-format json responses, including pretty-printed complete JSON payloads
- propagate partial agent results through the MCP response status
- document Grok setup and bump package/server metadata to 0.10.0

## Validation
- npm run check
- npm run build
- npm test
- manual smoke test through Claude Code MCP using the grok-smoke agent