### PR TITLE
Enforce Grok permission levels via OS sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,11 +327,11 @@ Which execution engine to use:
 **`AGENT_PERMISSION`**
 Approval/sandbox level the sub-agent runs with. Default: `"safe-edit"`.
 
-- `"read-only"` — investigation/review only, no edits or shell writes (codex `-s read-only` / claude+glm `--permission-mode plan` / gemini `--approval-mode plan` / cursor `--mode plan` / grok `--permission-mode dontAsk`)
-- `"safe-edit"` — auto-approve edits and suppress prompts (codex `-s workspace-write` + `approval_policy=never` / claude+glm `--permission-mode acceptEdits` / gemini `--approval-mode auto_edit` / cursor `--trust` / grok `--permission-mode auto`)
+- `"read-only"` — investigation/review only, no edits or shell writes (codex `-s read-only` / claude+glm `--permission-mode plan` / gemini `--approval-mode plan` / cursor `--mode plan` / grok `--sandbox read-only`)
+- `"safe-edit"` — auto-approve edits and suppress prompts (codex `-s workspace-write` + `approval_policy=never` / claude+glm `--permission-mode acceptEdits` / gemini `--approval-mode auto_edit` / cursor `--trust` / grok `--sandbox workspace`)
 - `"yolo"` — bypass all approvals and sandboxing. Use with care.
 
-Sub-agents have no stdin, so any approval prompt would deadlock the run. The default `safe-edit` removes prompts; the depth of sandboxing depends on the CLI — codex enforces a `workspace-write` sandbox, while claude / glm / gemini / cursor / grok only auto-approve and do not jail edits to the workspace. Grok runs also pass `--always-approve` so headless runs do not cancel while waiting for user approval; `AGENT_PERMISSION` still selects Grok's permission mode. If you need strict containment, use `read-only` and run privileged steps separately.
+Sub-agents have no stdin, so any approval prompt would deadlock the run. The default `safe-edit` removes prompts; the depth of sandboxing depends on the CLI — codex and grok enforce a workspace-level sandbox (codex `workspace-write`, grok `--sandbox workspace`), while claude / glm / gemini / cursor only auto-approve and do not jail edits to the workspace. Grok fixes `--permission-mode bypassPermissions` (its `--permission-mode` only enforces that value via the flag) and uses the kernel-enforced `--sandbox` profile to confine writes per `AGENT_PERMISSION`. If you need strict containment, use `read-only` and run privileged steps separately.
 
 **`CLI_API_KEY`**
 Z.ai API token for `AGENT_TYPE=glm`. It is forwarded to the Claude Code binary as `ANTHROPIC_AUTH_TOKEN` and never passed as a CLI argument. If you add or change it in your MCP client configuration, restart or reconnect the MCP server so the running process receives the new environment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-agents-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-agents-mcp",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sub-agents-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "mcpName": "io.github.shinpr/sub-agents-mcp",
   "description": "MCP server for delegating tasks to specialized AI assistants in Cursor, Claude Code, Codex, Gemini, GLM, and Grok",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/sub-agents-mcp",
     "source": "github"
   },
-  "version": "0.10.0",
+  "version": "0.10.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "sub-agents-mcp",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/execution/AgentExecutor.ts
+++ b/src/execution/AgentExecutor.ts
@@ -173,10 +173,12 @@ const PERMISSION_FLAGS: Record<AgentType, Record<AgentPermission, readonly strin
     'safe-edit': ['--trust'],
     yolo: ['-f', '--trust'],
   },
+  // Grok's --permission-mode enforces only bypassPermissions via the flag, so
+  // the level is enforced by the kernel --sandbox profile (always explicit).
   grok: {
-    'read-only': ['--permission-mode', 'dontAsk'],
-    'safe-edit': ['--permission-mode', 'auto'],
-    yolo: ['--permission-mode', 'bypassPermissions'],
+    'read-only': ['--permission-mode', 'bypassPermissions', '--sandbox', 'read-only'],
+    'safe-edit': ['--permission-mode', 'bypassPermissions', '--sandbox', 'workspace'],
+    yolo: ['--permission-mode', 'bypassPermissions', '--sandbox', 'off'],
   },
 }
 
@@ -502,13 +504,13 @@ export class AgentExecutor {
     const perm = this.permissionFlags()
     const cwd = params.cwd || process.cwd()
     const formattedPrompt = this.formatSystemUserPrompt(params)
+    // Approval mode + sandbox live in PERMISSION_FLAGS.grok (via perm).
     const args = [
       ...perm,
       '--cwd',
       cwd,
       '--output-format',
       'json',
-      '--always-approve',
       '--verbatim',
       '-p',
       formattedPrompt,

--- a/src/execution/__tests__/AgentExecutor.test.ts
+++ b/src/execution/__tests__/AgentExecutor.test.ts
@@ -717,9 +717,21 @@ describe('AgentExecutor', () => {
       { agent: 'cursor', perm: 'safe-edit', expected: ['--trust'] },
       { agent: 'cursor', perm: 'yolo', expected: ['-f', '--trust'] },
       // grok
-      { agent: 'grok', perm: 'read-only', expected: ['--permission-mode', 'dontAsk'] },
-      { agent: 'grok', perm: 'safe-edit', expected: ['--permission-mode', 'auto'] },
-      { agent: 'grok', perm: 'yolo', expected: ['--permission-mode', 'bypassPermissions'] },
+      {
+        agent: 'grok',
+        perm: 'read-only',
+        expected: ['--permission-mode', 'bypassPermissions', '--sandbox', 'read-only'],
+      },
+      {
+        agent: 'grok',
+        perm: 'safe-edit',
+        expected: ['--permission-mode', 'bypassPermissions', '--sandbox', 'workspace'],
+      },
+      {
+        agent: 'grok',
+        perm: 'yolo',
+        expected: ['--permission-mode', 'bypassPermissions', '--sandbox', 'off'],
+      },
     ]
 
     it.each(cases)('should prepend $expected for agent=$agent permission=$perm', async ({
@@ -804,12 +816,13 @@ describe('AgentExecutor', () => {
       expect(args).toEqual(
         expect.arrayContaining([
           '--permission-mode',
-          'dontAsk',
+          'bypassPermissions',
+          '--sandbox',
+          'read-only',
           '--cwd',
           '/tmp',
           '--output-format',
           'json',
-          '--always-approve',
           '--verbatim',
         ])
       )


### PR DESCRIPTION
## Summary

The Grok backend mapped `AGENT_PERMISSION` levels to `--permission-mode` values (`dontAsk` / `auto` / `bypassPermissions`). But per Grok's own docs, `--permission-mode` **only enforces `bypassPermissions` via the CLI flag** — `dontAsk` and `auto` are "accepted but not yet enforced." Combined with the `--always-approve` that `buildGrokArgs` always passed, this meant:

- **`safe-edit` had no containment** — writes and shell commands ran anywhere, effectively `yolo`.
- **`read-only` returned cancelled/partial results** instead of doing clean read-only work.
- The differentiation relied on flag values the vendor documents as not enforced (fragile across versions).

This switches enforcement to Grok's kernel-level `--sandbox` (Seatbelt on macOS, Landlock on Linux). All levels run with `--permission-mode bypassPermissions` and are differentiated by an explicit sandbox profile:

| `AGENT_PERMISSION` | sandbox | effect |
|---|---|---|
| `read-only` | `--sandbox read-only` | writes blocked by the kernel |
| `safe-edit` | `--sandbox workspace` | writes confined to the working directory |
| `yolo` | `--sandbox off` | unrestricted |

Every level names its sandbox explicitly, so a change to the CLI's default profile can't alter behavior. The now-redundant `--always-approve` is dropped from `buildGrokArgs` (`bypassPermissions` is the same knob).

> Note: sandbox filesystem confinement is enforced on both macOS and Linux. Child-process network blocking for `read-only` is Linux-only; on macOS it is a no-op.

## Verification

- `--sandbox` profiles confirmed against Grok 0.2.93 docs and `~/.grok/sandbox-events.jsonl` kernel events.
- End-to-end through the built `AgentExecutor` against real `grok`:
  - `read-only` → write tool and shell fallback both kernel-blocked (`FsViolation`), no file created, clean `success` (no more cancel/partial).
  - `safe-edit` → file written to CWD, `success`.
- Full quality suite green: tsc build, Biome check + lint, and `vitest run` (335/335 tests).

## Version

Bumps version to 0.10.1 (package.json, package-lock.json, server.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)