### PR TITLE
Add OpenCode backend and global model controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Bring Claude Code–style sub-agents to any MCP-compatible tool.
 
-This MCP server lets you define task-specific AI agents (like "test-writer" or "code-reviewer") in markdown files, and execute them via Cursor CLI, Claude Code, Codex, Gemini CLI, GLM, or Grok Build backends.
+This MCP server lets you define task-specific AI agents (like "test-writer" or "code-reviewer") in markdown files, and execute them via Cursor CLI, Claude Code, Codex, Gemini CLI, GLM, Grok Build, or OpenCode backends.
 
 ## Why?
 
@@ -14,7 +14,7 @@ Claude Code offers powerful sub-agent workflows—but they're limited to its own
 **Concrete benefits:**
 - Define reusable agents once, use them across multiple tools
 - Share agent definitions within teams regardless of IDE choice
-- Leverage Cursor CLI, Claude Code, Codex, Gemini CLI, GLM, or Grok Build capabilities from any MCP client
+- Leverage Cursor CLI, Claude Code, Codex, Gemini CLI, GLM, Grok Build, or OpenCode capabilities from any MCP client
 
 → [Read the full story](https://dev.to/shinpr/bringing-claude-codes-sub-agents-to-any-mcp-compatible-tool-1hb9)
 
@@ -25,10 +25,11 @@ Claude Code offers powerful sub-agent workflows—but they're limited to its own
 | | sub-agents-mcp | sub-agents-skills |
 |---|---|---|
 | **Setup** | MCP configuration required | Copy skill files to your environment |
-| **Features** | Session management, error handling | Minimal |
-| **Stability** | More robust | Lightweight |
+| **Configuration** | One backend/model policy per MCP server | Backend/model/permission per agent frontmatter |
+| **Agent discovery** | Fixed `AGENTS_DIR` | Project-local `.agents` or `SUB_AGENTS_DIR` |
+| **Strengths** | Sessions, MCP resources, structured responses, centralized policy | Lightweight setup and mixed backends in one project |
 
-Choose **sub-agents-mcp** for production use with reliability features. Choose **sub-agents-skills** for quick setup in Skill-compatible environments.
+Choose **sub-agents-mcp** when you want a centrally configured execution service. Choose **sub-agents-skills** when each agent should select its own backend and model in a Skill-compatible environment.
 
 ## Table of Contents
 
@@ -53,6 +54,7 @@ Choose **sub-agents-mcp** for production use with reliability features. Choose *
   - `gemini` CLI (from Gemini CLI — requires `GEMINI_API_KEY`)
   - `glm` backend (uses the Claude Code `claude` CLI with a Z.ai token)
   - `grok` CLI (from Grok Build)
+  - `opencode` CLI (from OpenCode)
 - An MCP-compatible tool (Cursor IDE, Claude Desktop, Windsurf, etc.)
 
 ## Quick Start
@@ -133,6 +135,13 @@ Set `AGENT_TYPE` to `glm` and add `CLI_API_KEY` to the MCP server environment in
 curl -fsSL https://x.ai/cli/install.sh | bash
 ```
 
+**For OpenCode users:**
+```bash
+brew install anomalyco/tap/opencode
+```
+
+Configure providers and credentials in OpenCode normally. Each MCP invocation uses isolated data and state directories to avoid concurrent session database locks while continuing to use your normal configuration and credentials.
+
 ### 3. Configure MCP
 
 Add this to your MCP configuration file:
@@ -148,7 +157,7 @@ Add this to your MCP configuration file:
       "args": ["-y", "sub-agents-mcp"],
       "env": {
         "AGENTS_DIR": "/absolute/path/to/your/agents-folder",
-        "AGENT_TYPE": "cursor"  // or "claude", "codex", "gemini", "glm", or "grok"
+        "AGENT_TYPE": "cursor"  // or "claude", "codex", "gemini", "glm", "grok", or "opencode"
       }
     }
   }
@@ -184,6 +193,9 @@ Sub-agents may fail to execute shell commands with permission errors. This happe
 
    # For Grok Build users
    grok
+
+   # For OpenCode users
+   opencode
    ```
 
 2. When prompted to allow commands (e.g., "Add Shell(cd), Shell(make) to allowlist?"), approve them
@@ -321,17 +333,34 @@ Which execution engine to use:
 - `"codex"` - uses `codex` CLI (OpenAI Codex)
 - `"glm"` - uses the Claude Code `claude` CLI against GLM's Z.ai endpoint
 - `"grok"` - uses `grok` CLI (Grok Build)
+- `"opencode"` - uses `opencode` CLI and its configured provider
 
 ### Optional Settings
 
 **`AGENT_PERMISSION`**
 Approval/sandbox level the sub-agent runs with. Default: `"safe-edit"`.
 
-- `"read-only"` — investigation/review only, no edits or shell writes (codex `-s read-only` / claude+glm `--permission-mode plan` / gemini `--approval-mode plan` / cursor `--mode plan` / grok `--sandbox read-only`)
-- `"safe-edit"` — auto-approve edits and suppress prompts (codex `-s workspace-write` + `approval_policy=never` / claude+glm `--permission-mode acceptEdits` / gemini `--approval-mode auto_edit` / cursor `--trust` / grok `--sandbox workspace`)
+- `"read-only"` — investigation/review only, no edits or shell writes (codex `-s read-only` / claude+glm `--permission-mode plan` / gemini `--approval-mode plan` / cursor `--mode plan` / grok `--sandbox read-only` / OpenCode deny rules)
+- `"safe-edit"` — auto-approve edits and suppress prompts (codex `-s workspace-write` + `approval_policy=never` / claude+glm `--permission-mode acceptEdits` / gemini `--approval-mode auto_edit` / cursor `--trust` / grok `--sandbox workspace` / OpenCode permission rules)
 - `"yolo"` — bypass all approvals and sandboxing. Use with care.
 
-Sub-agents have no stdin, so any approval prompt would deadlock the run. The default `safe-edit` removes prompts; the depth of sandboxing depends on the CLI — codex and grok enforce a workspace-level sandbox (codex `workspace-write`, grok `--sandbox workspace`), while claude / glm / gemini / cursor only auto-approve and do not jail edits to the workspace. Grok fixes `--permission-mode bypassPermissions` (its `--permission-mode` only enforces that value via the flag) and uses the kernel-enforced `--sandbox` profile to confine writes per `AGENT_PERMISSION`. If you need strict containment, use `read-only` and run privileged steps separately.
+Sub-agents have no stdin, so any approval prompt would deadlock the run. The default `safe-edit` removes prompts; the depth of sandboxing depends on the CLI — codex and grok enforce a workspace-level sandbox (codex `workspace-write`, grok `--sandbox workspace`), while claude / glm / gemini / cursor only auto-approve and do not jail edits to the workspace. OpenCode's permission configuration is also not an OS-level sandbox and cannot confine every side effect of programs launched through bash. Grok fixes `--permission-mode bypassPermissions` and uses the kernel-enforced `--sandbox` profile to confine writes per `AGENT_PERMISSION`. If you need strict containment, use a sandbox-backed backend.
+
+OpenCode custom and MCP tools follow your OpenCode permissions even in `read-only`; explicitly deny any added tool that can cause side effects.
+
+**`AGENT_MODEL`**
+Optional model override applied to every execution by this MCP server. The value is passed to the selected backend as `--model`. When omitted, the backend uses its configured default.
+
+```json
+"AGENT_MODEL": "gpt-5.6-luna"
+```
+
+OpenCode model names normally use `provider/model` syntax.
+
+**`AGENT_EFFORT`**
+Optional backend/model-specific reasoning level or model variant. It is passed to Codex as `model_reasoning_effort`, Claude/GLM as `--effort`, Grok as `--reasoning-effort`, and OpenCode as `--variant`. Cursor and Gemini do not support this setting; the MCP server rejects that configuration at startup.
+
+Accepted values depend on the selected backend and model. The MCP server forwards the value unchanged.
 
 **`CLI_API_KEY`**
 Z.ai API token for `AGENT_TYPE=glm`. It is forwarded to the Claude Code binary as `ANTHROPIC_AUTH_TOKEN` and never passed as a CLI argument. If you add or change it in your MCP client configuration, restart or reconnect the MCP server so the running process receives the new environment.
@@ -346,7 +375,7 @@ Each CLI normally reads settings from project-level directories (`.claude/`, `.c
 
 Applied to: `claude`, `cursor`, `codex`.
 
-Note: Gemini CLI and Grok Build do not support custom settings paths, so this option has no effect when `AGENT_TYPE` is `gemini` or `grok`. The `glm` backend also ignores this setting to avoid mixing Claude settings into the Z.ai-backed subprocess.
+Note: Gemini CLI, Grok Build, and OpenCode do not use this option, so it has no effect when `AGENT_TYPE` is `gemini`, `grok`, or `opencode`. OpenCode continues its normal XDG/project configuration discovery. The `glm` backend also ignores this setting to avoid mixing Claude settings into the Z.ai-backed subprocess.
 
 Example with custom settings:
 ```json
@@ -463,6 +492,9 @@ Make sure the Claude Code `claude` CLI is installed, then set `CLI_API_KEY` to y
 **If using Grok Build:**
 Make sure the `grok` CLI is installed and accessible.
 
+**If using OpenCode:**
+Make sure the `opencode` CLI is installed and that its provider credentials are configured. The MCP server gives every invocation an isolated OpenCode data/state directory to prevent concurrent SQLite session locks.
+
 ### Agent not found
 
 Check that:
@@ -472,7 +504,7 @@ Check that:
 
 ### Other execution errors
 
-1. Verify `AGENT_TYPE` is set correctly (`cursor`, `claude`, `gemini`, `codex`, `glm`, or `grok`)
+1. Verify `AGENT_TYPE` is set correctly (`cursor`, `claude`, `gemini`, `codex`, `glm`, `grok`, or `opencode`)
 2. Ensure your chosen CLI tool is installed and accessible
 3. Double-check that all environment variables are set in the MCP config
 
@@ -524,14 +556,14 @@ The startup overhead is an intentional trade-off: the system favors clarity and 
 
 ## How It Works
 
-This MCP server acts as a bridge between your AI tool and a supported execution engine (Cursor CLI, Claude Code, Gemini CLI, Codex, GLM via Z.ai, or Grok Build).
+This MCP server acts as a bridge between your AI tool and a supported execution engine (Cursor CLI, Claude Code, Gemini CLI, Codex, GLM via Z.ai, Grok Build, or OpenCode).
 
 **The flow:**
 
 1. You configure the MCP server in your client (Cursor, Claude Desktop, etc.)
 2. The client automatically launches `sub-agents-mcp` as a background process when it starts
 3. When your main AI assistant needs a sub-agent, it makes an MCP tool call
-4. The MCP server reads the agent definition (markdown file) and invokes the selected CLI (`cursor-agent`, `claude`, `gemini`, `codex`, `glm` via the `claude` binary, or `grok`)
+4. The MCP server reads the agent definition (markdown file) and invokes the globally configured CLI (`cursor-agent`, `claude`, `gemini`, `codex`, `glm` via the `claude` binary, `grok`, or `opencode`)
 5. The execution engine runs the agent and streams results back through the MCP server
 6. Your main assistant receives the results and continues working
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-agents-mcp",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-agents-mcp",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "sub-agents-mcp",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "mcpName": "io.github.shinpr/sub-agents-mcp",
-  "description": "MCP server for delegating tasks to specialized AI assistants in Cursor, Claude Code, Codex, Gemini, GLM, and Grok",
+  "description": "MCP server for delegating tasks to specialized AI assistants in Cursor, Claude Code, Codex, Gemini, GLM, Grok, and OpenCode",
   "type": "module",
   "main": "dist/index.js",
   "files": [
@@ -27,6 +27,7 @@
     "glm",
     "z.ai",
     "grok",
+    "opencode",
     "llm",
     "cli",
     "agent-orchestration"

--- a/server.json
+++ b/server.json
@@ -1,20 +1,20 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shinpr/sub-agents-mcp",
-  "description": "MCP server for AI sub-agent delegation across Cursor, Claude, Codex, Gemini, GLM, and Grok",
+  "description": "MCP server for AI sub-agent delegation across Cursor, Claude, Codex, Gemini, GLM, Grok, and OpenCode",
   "vendor": "Shinsuke Kagawa",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/shinpr/sub-agents-mcp",
     "source": "github"
   },
-  "version": "0.10.1",
+  "version": "0.11.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "sub-agents-mcp",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
         },
         {
           "name": "AGENT_TYPE",
-          "description": "Type of AI CLI to use: 'cursor', 'claude', 'gemini', 'codex', 'glm', or 'grok'",
+          "description": "Type of AI CLI to use: 'cursor', 'claude', 'gemini', 'codex', 'glm', 'grok', or 'opencode'",
           "isRequired": true,
           "format": "string",
           "isSecret": false
@@ -36,6 +36,20 @@
         {
           "name": "AGENT_PERMISSION",
           "description": "Approval/sandbox level for sub-agents: 'read-only', 'safe-edit' (default), or 'yolo'",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "AGENT_MODEL",
+          "description": "Optional model override applied to every sub-agent execution by this MCP server",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "AGENT_EFFORT",
+          "description": "Optional backend-specific reasoning effort or model variant. Supported by codex, claude, glm, grok, and opencode.",
           "isRequired": false,
           "format": "string",
           "isSecret": false
@@ -84,7 +98,7 @@
         },
         {
           "name": "AGENTS_SETTINGS_PATH",
-          "description": "Path to CLI settings file/directory. Claude: --settings arg, Cursor: CURSOR_CONFIG_DIR, Codex: CODEX_HOME. Gemini/Grok not supported.",
+          "description": "Path to CLI settings file/directory. Claude: --settings arg, Cursor: CURSOR_CONFIG_DIR, Codex: CODEX_HOME. Gemini/Grok/OpenCode not supported.",
           "isRequired": false,
           "format": "string",
           "isSecret": false
@@ -119,6 +133,7 @@
     "glm",
     "z.ai",
     "grok",
+    "opencode",
     "llm",
     "cli",
     "agent-orchestration"

--- a/src/__tests__/integration/RunAgentTool.integration.test.ts
+++ b/src/__tests__/integration/RunAgentTool.integration.test.ts
@@ -325,6 +325,44 @@ describe('RunAgentTool', () => {
       expect(result.structuredContent).toHaveProperty('exit_code', 1)
     })
 
+    it('should return normalized agent errors without nested raw JSON', async () => {
+      const params = {
+        agent: 'failing-agent',
+        prompt: 'Test prompt',
+        cwd: process.cwd(),
+      }
+      const errorMessage = 'UnknownError: Provider failed (ref: error-ref, sessionID: session-123)'
+
+      vi.spyOn(mockAgentExecutor, 'executeAgent').mockResolvedValue({
+        stdout: '{"type":"error"}',
+        stderr: '',
+        exitCode: 1,
+        executionTime: 50,
+        hasResult: true,
+        resultJson: {
+          type: 'result',
+          subtype: 'error',
+          is_error: true,
+          error: errorMessage,
+          error_type: 'UnknownError',
+          error_ref: 'error-ref',
+          session_id: 'session-123',
+        },
+      })
+
+      const result = await runAgentTool.execute(params)
+      const textContent = result.content.find((content) => content.type === 'text')
+      const parsedContent = JSON.parse(textContent?.text || '{}')
+
+      expect(result.isError).toBe(true)
+      expect(parsedContent).toMatchObject({
+        result: errorMessage,
+        exit_code: 1,
+        status: 'error',
+      })
+      expect(parsedContent.result).not.toContain('{"type":"error"}')
+    })
+
     it('should include execution metadata in response', async () => {
       const params = {
         agent: 'test-agent',

--- a/src/__tests__/integration/RunAgentTool.integration.test.ts
+++ b/src/__tests__/integration/RunAgentTool.integration.test.ts
@@ -613,6 +613,30 @@ describe('RunAgentTool', () => {
       })
     })
 
+    it('should treat exit code 137 as success when a structured result was received', async () => {
+      const params = {
+        agent: 'normal-agent',
+        prompt: 'Test forced process cleanup',
+        cwd: process.cwd(),
+      }
+      vi.spyOn(mockAgentExecutor, 'executeAgent').mockResolvedValue({
+        stdout: '{"type":"result","result":"Completed"}',
+        stderr: '',
+        exitCode: 137,
+        executionTime: 100,
+        hasResult: true,
+        resultJson: { type: 'result', result: 'Completed' },
+      })
+
+      const result = await runAgentTool.execute(params)
+
+      expect(result.structuredContent).toMatchObject({
+        result: 'Completed',
+        status: 'success',
+        exit_code: 137,
+      })
+    })
+
     it('should preserve partial status from agent result JSON even with exit code 0', async () => {
       const params = {
         agent: 'partial-agent',

--- a/src/__tests__/integration/ServerConfig.integration.test.ts
+++ b/src/__tests__/integration/ServerConfig.integration.test.ts
@@ -50,6 +50,7 @@ describe('ServerConfig', () => {
     'codex',
     'glm',
     'grok',
+    'opencode',
   ] as const)('should accept AGENT_TYPE=%s', (agentType) => {
     vi.stubEnv('AGENTS_DIR', testAgentsDir)
     vi.stubEnv('AGENT_TYPE', agentType)
@@ -139,6 +140,42 @@ describe('ServerConfig', () => {
     vi.stubEnv('AGENT_PERMISSION', 'godmode')
 
     expect(() => new ServerConfig()).toThrow(/Invalid AGENT_PERMISSION/)
+  })
+
+  describe('model and effort configuration', () => {
+    it('should load global AGENT_MODEL and AGENT_EFFORT values', () => {
+      vi.stubEnv('AGENTS_DIR', testAgentsDir)
+      vi.stubEnv('AGENT_TYPE', 'codex')
+      vi.stubEnv('AGENT_MODEL', 'gpt-5.6-luna')
+      vi.stubEnv('AGENT_EFFORT', 'high')
+
+      const config = new ServerConfig()
+
+      expect(config.agentModel).toBe('gpt-5.6-luna')
+      expect(config.agentEffort).toBe('high')
+    })
+
+    it('should treat blank model and effort values as unset', () => {
+      vi.stubEnv('AGENTS_DIR', testAgentsDir)
+      vi.stubEnv('AGENT_MODEL', '   ')
+      vi.stubEnv('AGENT_EFFORT', '')
+
+      const config = new ServerConfig()
+
+      expect(config.agentModel).toBeUndefined()
+      expect(config.agentEffort).toBeUndefined()
+    })
+
+    it.each([
+      'cursor',
+      'gemini',
+    ] as const)('should reject AGENT_EFFORT for AGENT_TYPE=%s', (agentType) => {
+      vi.stubEnv('AGENTS_DIR', testAgentsDir)
+      vi.stubEnv('AGENT_TYPE', agentType)
+      vi.stubEnv('AGENT_EFFORT', 'high')
+
+      expect(() => new ServerConfig()).toThrow(/AGENT_EFFORT is not supported/)
+    })
   })
 
   it('should throw error when LOG_LEVEL is an unsupported value', () => {

--- a/src/__tests__/security/validation.test.ts
+++ b/src/__tests__/security/validation.test.ts
@@ -276,9 +276,9 @@ describe('Security Validation Tests', () => {
 
       // Verify the loaded agent file path is within the allowed directory
       expect(agent.filePath).toContain(testAgentsDir)
-      const resolvedAgentPath = path.resolve(agent.filePath)
-      const resolvedTestDir = path.resolve(testAgentsDir)
-      expect(resolvedAgentPath.startsWith(resolvedTestDir)).toBe(true)
+      const resolvedAgentPath = await fs.realpath(agent.filePath)
+      const resolvedTestDir = await fs.realpath(testAgentsDir)
+      expect(path.relative(resolvedTestDir, resolvedAgentPath).startsWith('..')).toBe(false)
     })
   })
 

--- a/src/agents/AgentManager.ts
+++ b/src/agents/AgentManager.ts
@@ -90,12 +90,22 @@ export class AgentManager {
    */
   private async loadAgentsFromDirectory(): Promise<Map<string, AgentDefinition>> {
     try {
-      const agentsDir = path.resolve(this.config.agentsDir)
+      const agentsDir = await fs.promises.realpath(path.resolve(this.config.agentsDir))
       this.logger.info('Starting agent discovery', { directory: agentsDir })
 
       const files = await fs.promises.readdir(agentsDir)
 
-      const agentFiles = files.filter((file) => file.endsWith('.md') || file.endsWith('.txt'))
+      const agentFiles = files
+        .filter((file) => file.endsWith('.md') || file.endsWith('.txt'))
+        .sort((left, right) => {
+          const leftName = left.replace(/\.(md|txt)$/, '')
+          const rightName = right.replace(/\.(md|txt)$/, '')
+          const nameOrder = leftName.localeCompare(rightName)
+          if (nameOrder !== 0) return nameOrder
+          if (left.endsWith('.md') && right.endsWith('.txt')) return -1
+          if (left.endsWith('.txt') && right.endsWith('.md')) return 1
+          return left.localeCompare(right)
+        })
 
       this.logger.info('Agent definition files discovered', {
         totalFiles: files.length,
@@ -107,22 +117,42 @@ export class AgentManager {
 
       for (const file of agentFiles) {
         const filePath = path.join(agentsDir, file)
+        const agentName = file.replace(/\.(md|txt)$/, '')
+        if (agents.has(agentName)) {
+          this.logger.warn('Duplicate agent definition ignored', {
+            name: agentName,
+            filePath,
+            selectedFilePath: agents.get(agentName)?.filePath,
+          })
+          continue
+        }
+
+        let resolvedFilePath: string
         try {
-          const agent = await this.loadAgentFromFile(filePath)
-          if (agent) {
-            agents.set(agent.name, agent)
-            this.logger.debug('Agent definition loaded successfully', {
-              name: agent.name,
-              filePath: agent.filePath,
-              description: agent.description,
-            })
-          }
+          resolvedFilePath = await fs.promises.realpath(filePath)
         } catch (error) {
           this.logger.error(
-            'Failed to load agent definition from file',
+            'Failed to resolve agent definition file',
             error instanceof Error ? error : undefined,
             { filePath }
           )
+          continue
+        }
+
+        if (!this.isWithinDirectory(agentsDir, resolvedFilePath)) {
+          throw new Error(
+            `Agent definition resolves outside the configured agents directory: ${file}`
+          )
+        }
+
+        const agent = await this.loadAgentFromFile(resolvedFilePath, agentName)
+        if (agent) {
+          agents.set(agentName, agent)
+          this.logger.debug('Agent definition loaded successfully', {
+            name: agent.name,
+            filePath: agent.filePath,
+            description: agent.description,
+          })
         }
       }
 
@@ -138,6 +168,9 @@ export class AgentManager {
         error instanceof Error ? error : undefined,
         { directory: this.config.agentsDir }
       )
+      if (error instanceof Error && error.message.startsWith('Agent definition resolves outside')) {
+        throw error
+      }
       throw new Error(`Failed to load agents from directory: ${this.config.agentsDir}`)
     }
   }
@@ -145,19 +178,19 @@ export class AgentManager {
   /**
    * Loads and parses a single agent definition from a file.
    *
-   * @param filePath - Absolute path to the agent definition file
+   * @param resolvedFilePath - Validated real path used for reading the definition
+   * @param agentName - Agent name derived from the discovered directory entry
    * @returns Promise resolving to the parsed agent definition or undefined
    */
-  private async loadAgentFromFile(filePath: string): Promise<AgentDefinition | undefined> {
+  private async loadAgentFromFile(
+    resolvedFilePath: string,
+    agentName: string
+  ): Promise<AgentDefinition | undefined> {
     try {
-      this.logger.debug('Loading agent definition from file', { filePath })
+      this.logger.debug('Loading agent definition from file', { filePath: resolvedFilePath })
 
-      const content = await fs.promises.readFile(filePath, 'utf-8')
-      const stats = await fs.promises.stat(filePath)
-
-      // Extract agent name from filename (without extension)
-      const fileName = path.basename(filePath)
-      const agentName = fileName.replace(/\.(md|txt)$/, '')
+      const content = await fs.promises.readFile(resolvedFilePath, 'utf-8')
+      const stats = await fs.promises.stat(resolvedFilePath)
 
       // Parse description from content (first line or first heading)
       const description = this.extractDescription(content)
@@ -166,7 +199,7 @@ export class AgentManager {
         name: agentName,
         description,
         content,
-        filePath,
+        filePath: resolvedFilePath,
         lastModified: stats.mtime,
       }
 
@@ -182,10 +215,18 @@ export class AgentManager {
       this.logger.error(
         'Error reading agent definition file',
         error instanceof Error ? error : undefined,
-        { filePath }
+        { filePath: resolvedFilePath }
       )
       return undefined
     }
+  }
+
+  private isWithinDirectory(root: string, candidate: string): boolean {
+    const relative = path.relative(root, candidate)
+    return (
+      relative === '' ||
+      (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+    )
   }
 
   /**

--- a/src/agents/__tests__/AgentManager.test.ts
+++ b/src/agents/__tests__/AgentManager.test.ts
@@ -9,6 +9,7 @@ vi.mock('node:fs', () => ({
       readdir: vi.fn(),
       readFile: vi.fn(),
       stat: vi.fn(),
+      realpath: vi.fn(),
     },
   },
 }))
@@ -19,10 +20,16 @@ vi.mock('node:path', () => ({
     resolve: vi.fn(),
     join: vi.fn(),
     basename: vi.fn(),
+    relative: vi.fn(),
+    isAbsolute: vi.fn(),
+    sep: '/',
   },
   resolve: vi.fn(),
   join: vi.fn(),
   basename: vi.fn(),
+  relative: vi.fn(),
+  isAbsolute: vi.fn(),
+  sep: '/',
 }))
 
 // Import mocked modules
@@ -33,9 +40,12 @@ import path from 'node:path'
 const mockReaddir = vi.mocked(fs.promises.readdir)
 const mockReadFile = vi.mocked(fs.promises.readFile)
 const mockStat = vi.mocked(fs.promises.stat)
+const mockRealpath = vi.mocked(fs.promises.realpath)
 const mockResolve = vi.mocked(path.resolve)
 const mockJoin = vi.mocked(path.join)
 const mockBasename = vi.mocked(path.basename)
+const mockRelative = vi.mocked(path.relative)
+const mockIsAbsolute = vi.mocked(path.isAbsolute)
 
 describe('AgentManager', () => {
   let agentManager: AgentManager
@@ -46,9 +56,19 @@ describe('AgentManager', () => {
     mockReaddir.mockClear()
     mockReadFile.mockClear()
     mockStat.mockClear()
+    mockRealpath.mockClear()
     mockResolve.mockClear()
     mockJoin.mockClear()
     mockBasename.mockClear()
+    mockRelative.mockClear()
+    mockIsAbsolute.mockClear()
+
+    mockRealpath.mockImplementation(async (filePath) => filePath)
+    mockRelative.mockImplementation((from, to) => {
+      const prefix = `${from}/`
+      return to.startsWith(prefix) ? to.slice(prefix.length) : `../${to}`
+    })
+    mockIsAbsolute.mockImplementation((filePath) => filePath.startsWith('/'))
 
     // Create mock config
     mockConfig = {
@@ -68,9 +88,12 @@ describe('AgentManager', () => {
     mockReaddir.mockClear()
     mockReadFile.mockClear()
     mockStat.mockClear()
+    mockRealpath.mockClear()
     mockResolve.mockClear()
     mockJoin.mockClear()
     mockBasename.mockClear()
+    mockRelative.mockClear()
+    mockIsAbsolute.mockClear()
   })
 
   describe('File Discovery', () => {
@@ -111,6 +134,76 @@ describe('AgentManager', () => {
       // Assert
       expect(agents).toHaveLength(0)
       expect(mockReaddir).toHaveBeenCalledWith('/test/agents')
+    })
+
+    it('should prefer markdown when .md and .txt definitions share a name', async () => {
+      mockReaddir.mockResolvedValue(['reviewer.txt', 'reviewer.md'] as unknown as fs.Dirent[])
+      mockStat.mockResolvedValue({ mtime: new Date('2025-01-01') } as fs.Stats)
+      mockReadFile.mockResolvedValue('# Markdown Reviewer')
+      mockResolve.mockReturnValue('/test/agents')
+      mockJoin.mockImplementation((dir, file) => `${dir}/${file}`)
+      mockBasename.mockImplementation((filePath) => filePath.split('/').at(-1) || '')
+
+      const agents = await agentManager.listAgents()
+
+      expect(agents).toHaveLength(1)
+      expect(agents[0]?.filePath).toBe('/test/agents/reviewer.md')
+      expect(mockReadFile).toHaveBeenCalledTimes(1)
+    })
+
+    it('should reject an agent definition symlink that resolves outside AGENTS_DIR', async () => {
+      mockReaddir.mockResolvedValue(['outside.md'] as unknown as fs.Dirent[])
+      mockResolve.mockReturnValue('/test/agents')
+      mockJoin.mockImplementation((dir, file) => `${dir}/${file}`)
+      mockRealpath
+        .mockResolvedValueOnce('/test/agents')
+        .mockResolvedValueOnce('/outside/outside.md')
+      mockRelative.mockReturnValue('../../outside/outside.md')
+
+      await expect(agentManager.getAgent('outside')).rejects.toThrow(/resolves outside/)
+      expect(mockReadFile).not.toHaveBeenCalled()
+    })
+
+    it('should preserve the discovered name for a symlink within AGENTS_DIR', async () => {
+      mockReaddir.mockResolvedValue(['alias.md'] as unknown as fs.Dirent[])
+      mockResolve.mockReturnValue('/test/agents')
+      mockJoin.mockImplementation((dir, file) => `${dir}/${file}`)
+      mockRealpath
+        .mockResolvedValueOnce('/test/agents')
+        .mockResolvedValueOnce('/test/agents/reviewer.md')
+      mockRelative.mockReturnValue('reviewer.md')
+      mockReadFile.mockResolvedValue('# Reviewer')
+      mockStat.mockResolvedValue({ mtime: new Date('2025-01-01') } as fs.Stats)
+
+      const agents = await agentManager.listAgents()
+
+      expect(agents).toHaveLength(1)
+      expect(agents[0]).toMatchObject({
+        name: 'alias',
+        filePath: '/test/agents/reviewer.md',
+      })
+      expect(mockReadFile).toHaveBeenCalledWith('/test/agents/reviewer.md', 'utf-8')
+    })
+
+    it('should skip a broken symlink and continue loading other agents', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const missing = Object.assign(new Error('Missing symlink target'), { code: 'ENOENT' })
+      mockReaddir.mockResolvedValue(['broken.md', 'healthy.md'] as unknown as fs.Dirent[])
+      mockResolve.mockReturnValue('/test/agents')
+      mockJoin.mockImplementation((dir, file) => `${dir}/${file}`)
+      mockRealpath
+        .mockResolvedValueOnce('/test/agents')
+        .mockRejectedValueOnce(missing)
+        .mockResolvedValueOnce('/test/agents/healthy.md')
+      mockRelative.mockReturnValue('healthy.md')
+      mockReadFile.mockResolvedValue('# Healthy Agent')
+      mockStat.mockResolvedValue({ mtime: new Date('2025-01-01') } as fs.Stats)
+
+      const agents = await agentManager.listAgents()
+
+      expect(agents).toHaveLength(1)
+      expect(agents[0]?.name).toBe('healthy')
+      expect(consoleSpy).toHaveBeenCalled()
     })
 
     it('should handle directory read errors', async () => {
@@ -319,7 +412,8 @@ This agent does amazing things.`
 
       mockReaddir.mockResolvedValue(mockFiles as unknown as fs.Dirent[])
       mockStat.mockResolvedValue(mockStats as fs.Stats)
-      mockReadFile.mockResolvedValueOnce(targetContent).mockResolvedValueOnce(otherContent)
+      // Discovery is sorted by agent name, so other-agent is loaded first.
+      mockReadFile.mockResolvedValueOnce(otherContent).mockResolvedValueOnce(targetContent)
       mockResolve.mockReturnValue('/test/agents')
       mockJoin.mockImplementation((dir, file) => `${dir}/${file}`)
       mockBasename.mockImplementation((filePath) => {

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_AGENT_PERMISSION,
   isAgentPermission,
   isAgentType,
+  supportsAgentEffort,
 } from '../execution/AgentExecutor.js'
 import { isLogLevel, LOG_LEVELS, type LogLevel } from '../utils/Logger.js'
 
@@ -19,8 +20,10 @@ import { isLogLevel, LOG_LEVELS, type LogLevel } from '../utils/Logger.js'
  * - SERVER_NAME: Name identifier for the MCP server (default: 'sub-agents-mcp-server')
  * - SERVER_VERSION: Version of the MCP server (default: '1.0.0')
  * - AGENTS_DIR: Directory containing agent definition files (REQUIRED - must be absolute path)
- * - AGENT_TYPE: Type of agent to use ('cursor' | 'claude' | 'gemini' | 'codex' | 'glm' | 'grok') (default: 'cursor')
+ * - AGENT_TYPE: Type of agent to use (default: 'cursor')
  * - AGENT_PERMISSION: Approval/sandbox level for sub-agents ('read-only' | 'safe-edit' | 'yolo') (default: 'safe-edit')
+ * - AGENT_MODEL: Optional model override for every agent execution
+ * - AGENT_EFFORT: Optional backend-specific reasoning effort/model variant
  * - LOG_LEVEL: Log level for server operations (default: 'info')
  * - SESSION_ENABLED: Enable session management functionality (default: false)
  * - SESSION_DIR: Directory for storing session files (default: '.mcp-sessions')
@@ -42,6 +45,12 @@ export class ServerConfig {
 
   /** Approval/sandbox level for sub-agent execution */
   public readonly agentPermission: AgentPermission
+
+  /** Optional model override applied to every execution */
+  public readonly agentModel: string | undefined
+
+  /** Optional backend-specific reasoning effort or model variant */
+  public readonly agentEffort: string | undefined
 
   /** Log level for server operations */
   public readonly logLevel: LogLevel
@@ -116,6 +125,18 @@ export class ServerConfig {
       )
     }
 
+    const agentModelEnv = process.env['AGENT_MODEL']?.trim()
+    this.agentModel = agentModelEnv || undefined
+
+    const agentEffortEnv = process.env['AGENT_EFFORT']?.trim()
+    this.agentEffort = agentEffortEnv || undefined
+    if (this.agentEffort && !supportsAgentEffort(this.agentType)) {
+      throw new Error(
+        `AGENT_EFFORT is not supported for AGENT_TYPE="${this.agentType}". ` +
+          'Supported types: codex, claude, glm, grok, opencode.'
+      )
+    }
+
     const logLevelEnv = process.env['LOG_LEVEL']?.trim()
     if (!logLevelEnv) {
       this.logLevel = 'info'
@@ -155,7 +176,7 @@ export class ServerConfig {
     // - Claude: passed as --settings argument
     // - Cursor: set as CURSOR_CONFIG_DIR environment variable
     // - Codex: set as CODEX_HOME environment variable
-    // - Gemini/Grok: not supported (upstream limitation)
+    // - Gemini/Grok/OpenCode: not supported (upstream limitation or normal config discovery)
     this.agentsSettingsPath = process.env['AGENTS_SETTINGS_PATH'] || undefined
 
     // Cursor API key: prefer CURSOR_API_KEY, fall back to CLI_API_KEY for backward compatibility

--- a/src/execution/AgentExecutor.ts
+++ b/src/execution/AgentExecutor.ts
@@ -1,4 +1,8 @@
 import { type ChildProcess, spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { StringDecoder } from 'node:string_decoder'
 import type { ExecutionParams } from '../types/ExecutionParams.js'
 import { Logger, type LogLevel } from '../utils/Logger.js'
 import { StreamProcessor } from './StreamProcessor.js'
@@ -55,9 +59,12 @@ export interface ExecutionConfig {
    */
   executionTimeout: number
 
+  /** Maximum combined stdout/stderr bytes retained in memory. */
+  maxOutputBytes: number
+
   /**
    * Type of agent to use for execution.
-   * 'cursor', 'claude', 'gemini', 'codex', 'glm', or 'grok'
+   * 'cursor', 'claude', 'gemini', 'codex', 'glm', 'grok', or 'opencode'
    */
   agentType: AgentType
 
@@ -92,9 +99,18 @@ export interface ExecutionConfig {
    * Passed to the claude binary via ANTHROPIC_AUTH_TOKEN environment variable.
    */
   glmApiKey?: string
+
+  /** Optional model override applied to every execution by this MCP server. */
+  model?: string
+
+  /** Optional backend-specific reasoning effort or model variant. */
+  effort?: string
 }
 
 export const DEFAULT_EXECUTION_TIMEOUT = 300000 // 5 minutes
+const MAX_CAPTURED_OUTPUT_BYTES = 16 * 1024 * 1024
+
+const TERMINATION_GRACE_MS = 1000
 
 type EnvOverrides = Record<string, string | null>
 
@@ -110,12 +126,28 @@ const GLM_MISSING_API_KEY_ERROR =
  * Supported agent runtimes. Single source of truth for both runtime validation
  * (ServerConfig) and static typing.
  */
-export const AGENT_TYPES = ['cursor', 'claude', 'gemini', 'codex', 'glm', 'grok'] as const
+export const AGENT_TYPES = [
+  'cursor',
+  'claude',
+  'gemini',
+  'codex',
+  'glm',
+  'grok',
+  'opencode',
+] as const
 
 export type AgentType = (typeof AGENT_TYPES)[number]
 
 export function isAgentType(value: unknown): value is AgentType {
   return typeof value === 'string' && (AGENT_TYPES as readonly string[]).includes(value)
+}
+
+export const AGENT_EFFORT_SUPPORTED_TYPES = ['codex', 'claude', 'glm', 'grok', 'opencode'] as const
+
+export function supportsAgentEffort(
+  agentType: AgentType
+): agentType is (typeof AGENT_EFFORT_SUPPORTED_TYPES)[number] {
+  return (AGENT_EFFORT_SUPPORTED_TYPES as readonly AgentType[]).includes(agentType)
 }
 
 /**
@@ -180,6 +212,30 @@ const PERMISSION_FLAGS: Record<AgentType, Record<AgentPermission, readonly strin
     'safe-edit': ['--permission-mode', 'bypassPermissions', '--sandbox', 'workspace'],
     yolo: ['--permission-mode', 'bypassPermissions', '--sandbox', 'off'],
   },
+  // OpenCode permissions are supplied through OPENCODE_PERMISSION.
+  opencode: {
+    'read-only': [],
+    'safe-edit': [],
+    yolo: [],
+  },
+}
+
+const OPENCODE_PERMISSION_MAPPING: Record<AgentPermission, object | 'allow'> = {
+  'read-only': {
+    edit: 'deny',
+    bash: 'deny',
+    task: 'deny',
+    external_directory: 'deny',
+    question: 'deny',
+  },
+  'safe-edit': {
+    edit: 'allow',
+    bash: 'allow',
+    task: 'deny',
+    external_directory: 'deny',
+    question: 'deny',
+  },
+  yolo: 'allow',
 }
 
 /**
@@ -196,6 +252,7 @@ export function createExecutionConfig(
   // that bypasses TS) does not silently disable approval handling.
   return {
     executionTimeout: DEFAULT_EXECUTION_TIMEOUT,
+    maxOutputBytes: MAX_CAPTURED_OUTPUT_BYTES,
     ...overrides,
     permission: overrides?.permission ?? DEFAULT_AGENT_PERMISSION,
     agentType,
@@ -353,6 +410,8 @@ export class AgentExecutor {
         return this.buildCursorArgs(params, envOverrides)
       case 'grok':
         return this.buildGrokArgs(params, envOverrides)
+      case 'opencode':
+        return this.buildOpenCodeArgs(params, envOverrides)
     }
   }
 
@@ -376,6 +435,7 @@ export class AgentExecutor {
       // claude: handled via --settings argv below
       // glm: uses the claude binary, but intentionally avoids Claude settings.
       // grok: not supported (upstream limitation)
+      // opencode: uses its normal XDG/project configuration discovery.
       // gemini: not supported (upstream limitation)
     }
     return env
@@ -383,6 +443,42 @@ export class AgentExecutor {
 
   private permissionFlags(): readonly string[] {
     return PERMISSION_FLAGS[this.config.agentType][this.config.permission]
+  }
+
+  private invocationFlags(): string[] {
+    const flags = [...this.permissionFlags()]
+
+    if (this.config.model) {
+      flags.push('--model', this.config.model)
+    }
+
+    if (!this.config.effort) {
+      return flags
+    }
+
+    switch (this.config.agentType) {
+      case 'codex':
+        flags.push('-c', `model_reasoning_effort=${JSON.stringify(this.config.effort)}`)
+        break
+      case 'claude':
+      case 'glm':
+        flags.push('--effort', this.config.effort)
+        break
+      case 'grok':
+        flags.push('--reasoning-effort', this.config.effort)
+        break
+      case 'opencode':
+        flags.push('--variant', this.config.effort)
+        break
+      case 'cursor':
+      case 'gemini':
+        throw new Error(
+          `AGENT_EFFORT is not supported for AGENT_TYPE=${this.config.agentType}. ` +
+            `Supported types: ${AGENT_EFFORT_SUPPORTED_TYPES.join(', ')}.`
+        )
+    }
+
+    return flags
   }
 
   private formatSystemUserPrompt(params: ExecutionParams): string {
@@ -393,14 +489,14 @@ export class AgentExecutor {
     params: ExecutionParams,
     envOverrides: EnvOverrides
   ): { command: string; args: string[]; envOverrides: EnvOverrides } {
-    const perm = this.permissionFlags()
+    const flags = this.invocationFlags()
     // System context is concatenated into the user prompt rather than injected
     // via `-c model_instructions_file=...`: that flag fully replaces codex's
     // default system prompt, which removed the built-in tool-use guidance and
     // measurably increased exploration overhead and token usage in our tests.
     // Concatenation keeps codex's defaults intact and matches the cursor path.
     const formattedPrompt = this.formatSystemUserPrompt(params)
-    const args = [...perm, 'exec', '--json', '--skip-git-repo-check', formattedPrompt]
+    const args = [...flags, 'exec', '--json', '--skip-git-repo-check', formattedPrompt]
     return { command: 'codex', args, envOverrides }
   }
 
@@ -408,11 +504,11 @@ export class AgentExecutor {
     params: ExecutionParams,
     envOverrides: EnvOverrides
   ): { command: string; args: string[]; envOverrides: EnvOverrides } {
-    const perm = this.permissionFlags()
+    const flags = this.invocationFlags()
     const cwd = params.cwd || process.cwd()
     const systemPrompt = `cwd: ${cwd}\n\n${params.agent}`
     const args: string[] = [
-      ...perm,
+      ...flags,
       '--output-format',
       'stream-json',
       '--verbose',
@@ -436,11 +532,11 @@ export class AgentExecutor {
       throw new Error(GLM_MISSING_API_KEY_ERROR)
     }
 
-    const perm = this.permissionFlags()
+    const flags = this.invocationFlags()
     const cwd = params.cwd || process.cwd()
     const systemPrompt = `cwd: ${cwd}\n\n${params.agent}`
     const args: string[] = [
-      ...perm,
+      ...flags,
       '--output-format',
       'stream-json',
       '--verbose',
@@ -466,12 +562,12 @@ export class AgentExecutor {
     params: ExecutionParams,
     envOverrides: EnvOverrides
   ): { command: string; args: string[]; envOverrides: EnvOverrides } {
-    const perm = this.permissionFlags()
+    const flags = this.invocationFlags()
     // --skip-trust is unconditional: headless runs in untrusted folders are
     // refused without it (Gemini downgrades to interactive prompts which
     // deadlock here since we have no stdin).
     if (params.agentFilePath) {
-      const args = [...perm, '--skip-trust', '--output-format', 'stream-json', '-p', params.prompt]
+      const args = [...flags, '--skip-trust', '--output-format', 'stream-json', '-p', params.prompt]
       return {
         command: 'gemini',
         args,
@@ -479,7 +575,7 @@ export class AgentExecutor {
       }
     }
     const formattedPrompt = this.formatSystemUserPrompt(params)
-    const args = [...perm, '--skip-trust', '--output-format', 'stream-json', '-p', formattedPrompt]
+    const args = [...flags, '--skip-trust', '--output-format', 'stream-json', '-p', formattedPrompt]
     return { command: 'gemini', args, envOverrides }
   }
 
@@ -487,9 +583,9 @@ export class AgentExecutor {
     params: ExecutionParams,
     envOverrides: EnvOverrides
   ): { command: string; args: string[]; envOverrides: EnvOverrides } {
-    const perm = this.permissionFlags()
+    const flags = this.invocationFlags()
     const formattedPrompt = this.formatSystemUserPrompt(params)
-    const args = [...perm, '--output-format', 'json', '-p', formattedPrompt]
+    const args = [...flags, '--output-format', 'json', '-p', formattedPrompt]
     const env: EnvOverrides = { ...envOverrides }
     if (this.config.cursorApiKey) {
       env['CURSOR_API_KEY'] = this.config.cursorApiKey
@@ -501,12 +597,12 @@ export class AgentExecutor {
     params: ExecutionParams,
     envOverrides: EnvOverrides
   ): { command: string; args: string[]; envOverrides: EnvOverrides } {
-    const perm = this.permissionFlags()
+    const flags = this.invocationFlags()
     const cwd = params.cwd || process.cwd()
     const formattedPrompt = this.formatSystemUserPrompt(params)
     // Approval mode + sandbox live in PERMISSION_FLAGS.grok (via perm).
     const args = [
-      ...perm,
+      ...flags,
       '--cwd',
       cwd,
       '--output-format',
@@ -516,6 +612,23 @@ export class AgentExecutor {
       formattedPrompt,
     ]
     return { command: 'grok', args, envOverrides }
+  }
+
+  private buildOpenCodeArgs(
+    params: ExecutionParams,
+    envOverrides: EnvOverrides
+  ): { command: string; args: string[]; envOverrides: EnvOverrides } {
+    const flags = this.invocationFlags()
+    const formattedPrompt = this.formatSystemUserPrompt(params)
+    const args = [...flags, 'run', '--format', 'json', '--auto', formattedPrompt]
+    return {
+      command: 'opencode',
+      args,
+      envOverrides: {
+        ...envOverrides,
+        OPENCODE_PERMISSION: JSON.stringify(OPENCODE_PERMISSION_MAPPING[this.config.permission]),
+      },
+    }
   }
 
   private buildSpawnEnv(envOverrides: EnvOverrides): NodeJS.ProcessEnv {
@@ -528,6 +641,62 @@ export class AgentExecutor {
       }
     }
     return spawnEnv
+  }
+
+  private async prepareSpawnEnvironment(envOverrides: EnvOverrides): Promise<{
+    env: NodeJS.ProcessEnv
+    cleanup: () => Promise<void>
+  }> {
+    if (this.config.agentType !== 'opencode') {
+      return { env: this.buildSpawnEnv(envOverrides), cleanup: async () => {} }
+    }
+
+    const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'subagent-opencode-'))
+    const dataHome = path.join(tempDir, 'data')
+    const stateHome = path.join(tempDir, 'state')
+    const isolatedOpenCodeDir = path.join(dataHome, 'opencode')
+
+    try {
+      await fs.promises.mkdir(isolatedOpenCodeDir, { recursive: true })
+      await fs.promises.mkdir(stateHome, { recursive: true })
+
+      const defaultDataHome =
+        process.env['XDG_DATA_HOME'] || path.join(os.homedir(), '.local', 'share')
+      const authSource = path.join(defaultDataHome, 'opencode', 'auth.json')
+      const authDestination = path.join(isolatedOpenCodeDir, 'auth.json')
+
+      try {
+        await fs.promises.copyFile(authSource, authDestination)
+      } catch (error) {
+        const code = this.errorCode(error)
+        if (code !== 'ENOENT') {
+          this.logger.warn('Could not copy OpenCode authentication into isolated data home', {
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+      }
+
+      return {
+        env: this.buildSpawnEnv({
+          ...envOverrides,
+          XDG_DATA_HOME: dataHome,
+          XDG_STATE_HOME: stateHome,
+        }),
+        cleanup: async () => {
+          await fs.promises.rm(tempDir, { recursive: true, force: true })
+        },
+      }
+    } catch (error) {
+      await fs.promises.rm(tempDir, { recursive: true, force: true }).catch(() => {})
+      throw error
+    }
+  }
+
+  private errorCode(error: unknown): string | undefined {
+    if (typeof error !== 'object' || error === null || !('code' in error)) {
+      return undefined
+    }
+    return typeof error.code === 'string' ? error.code : undefined
   }
 
   /**
@@ -544,117 +713,187 @@ export class AgentExecutor {
     hasResult?: boolean
     resultJson?: unknown
   }> {
+    const { command, args, envOverrides } = this.buildCommandArgs(params)
+    const preparedEnvironment = await this.prepareSpawnEnvironment(envOverrides)
+
     return new Promise((resolve) => {
-      // Build command, args, and env based on agent type with system prompt separation
-      const { command, args, envOverrides } = this.buildCommandArgs(params)
-
-      // Build environment variables for spawn
-      const spawnEnv = this.buildSpawnEnv(envOverrides)
-
       this.logger.debug('Executing with spawn', {
         command,
         cwd: params.cwd || process.cwd(),
       })
 
-      // Spawn process
-      const childProcess: ChildProcess = spawn(command, args, {
-        cwd: params.cwd || process.cwd(),
-        stdio: ['ignore', 'pipe', 'pipe'], // stdin set to 'ignore' as cursor-agent receives prompt via args
-        shell: false,
-        env: spawnEnv,
-      })
+      let childProcess: ChildProcess
+      try {
+        childProcess = spawn(command, args, {
+          cwd: params.cwd || process.cwd(),
+          stdio: ['ignore', 'pipe', 'pipe'],
+          shell: false,
+          env: preparedEnvironment.env,
+        })
+      } catch (error) {
+        void preparedEnvironment.cleanup().finally(() => {
+          resolve({
+            stdout: '',
+            stderr: error instanceof Error ? error.message : String(error),
+            exitCode: this.errorCode(error) === 'ENOENT' ? 127 : 1,
+            hasResult: false,
+          })
+        })
+        return
+      }
 
-      // Initialize stream processor and buffers
       const streamProcessor = new StreamProcessor()
       let stdout = ''
       let stderr = ''
       let stdoutBuffer = ''
+      const stdoutDecoder = new StringDecoder('utf8')
+      const stderrDecoder = new StringDecoder('utf8')
+      let stdoutTruncated = false
+      let stderrTruncated = false
+      let capturedBytes = 0
+      let timedOut = false
+      let outputExceeded = false
+      let processError: Error | undefined
+      let settled = false
+      let forceKillTimer: NodeJS.Timeout | undefined
 
-      // No need to handle stdin as it's set to 'ignore'
       const executionTimeout = setTimeout(() => {
+        timedOut = true
         this.logger.warn('Execution timeout reached', {
           timeout: this.config.executionTimeout,
         })
-        childProcess.kill('SIGTERM')
-
-        // Get any result collected so far
-        const result = streamProcessor.getResult()
-        resolve({
-          stdout: result ? JSON.stringify(result) : stdout,
-          stderr: stderr || `Execution timeout: ${this.config.executionTimeout}ms`,
-          exitCode: 124, // Standard timeout exit code
-          hasResult: result !== null,
-          resultJson: result !== null ? result : undefined,
-        })
+        requestTermination()
       }, this.config.executionTimeout)
 
-      // Handle stdout stream with simplified processing
-      childProcess.stdout?.on('data', (data: Buffer) => {
-        const chunk = data.toString()
-        stdout += chunk
-        stdoutBuffer += chunk
-
-        // Process complete lines
-        const lines = stdoutBuffer.split('\n')
-        stdoutBuffer = lines.pop() || '' // Keep incomplete line in buffer
-
-        for (const line of lines) {
-          // Process line returns true when final JSON is detected
-          const isComplete = streamProcessor.processLine(line)
-
-          if (isComplete) {
-            // Ensure stdout contains the complete JSON result
-            const completeResult = streamProcessor.getResult()
-            if (completeResult) {
-              stdout = JSON.stringify(completeResult)
-            }
-            // Processing complete, kill the process
-            childProcess.kill('SIGTERM')
-            break
-          }
-        }
-      })
-
-      // Handle stderr stream
-      childProcess.stderr?.on('data', (data: Buffer) => {
-        stderr += data.toString()
-      })
-
-      childProcess.on('close', (code: number | null) => {
+      const clearTimers = () => {
         clearTimeout(executionTimeout)
+        if (forceKillTimer) clearTimeout(forceKillTimer)
+      }
 
-        // Get the final result JSON
+      const finish = async (code: number | null, signal?: NodeJS.Signals | null) => {
+        if (settled) return
+        settled = true
+        clearTimers()
+
+        if (!stdoutTruncated) {
+          const tail = stdoutDecoder.end()
+          stdout += tail
+          stdoutBuffer += tail
+        }
+        if (!stderrTruncated) {
+          stderr += stderrDecoder.end()
+        }
+
+        if (stdoutBuffer.trim()) {
+          streamProcessor.processLine(stdoutBuffer)
+          stdoutBuffer = ''
+        }
+
         let result = streamProcessor.getResult()
         if (result === null) {
           streamProcessor.processCompleteOutput(stdout)
           result = streamProcessor.getResult()
         }
 
+        let exitCode = code ?? (signal ? 128 + this.signalNumber(signal) : 1)
+        if (timedOut) exitCode = 124
+        if (outputExceeded || processError)
+          exitCode = this.errorCode(processError) === 'ENOENT' ? 127 : 1
+        const errors: string[] = []
+        if (stderr) errors.push(stderr)
+        if (timedOut) errors.push(`Execution timeout: ${this.config.executionTimeout}ms`)
+        if (outputExceeded) {
+          errors.push(`Sub-agent output exceeded ${this.config.maxOutputBytes} bytes`)
+        }
+        if (processError && !stderr) errors.push(processError.message)
+
+        try {
+          await preparedEnvironment.cleanup()
+        } catch (error) {
+          this.logger.warn('Failed to clean up per-run environment', {
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+
         resolve({
           stdout: result ? JSON.stringify(result) : stdout,
-          stderr,
-          exitCode: code || 0,
+          stderr: errors.join('\n'),
+          exitCode,
           hasResult: result !== null,
           resultJson: result !== null ? result : undefined,
+        })
+      }
+
+      const requestTermination = () => {
+        childProcess.kill('SIGTERM')
+        if (forceKillTimer) return
+        forceKillTimer = setTimeout(() => {
+          childProcess.kill('SIGKILL')
+        }, TERMINATION_GRACE_MS)
+      }
+
+      const captureChunk = (
+        data: Buffer,
+        decoder: StringDecoder,
+        markTruncated: () => void
+      ): string => {
+        const remaining = this.config.maxOutputBytes - capturedBytes
+        if (remaining <= 0) {
+          outputExceeded = true
+          markTruncated()
+          requestTermination()
+          return ''
+        }
+
+        const captured = data.length <= remaining ? data : data.subarray(0, remaining)
+        capturedBytes += captured.length
+        if (captured.length < data.length) {
+          outputExceeded = true
+          markTruncated()
+          requestTermination()
+        }
+        return decoder.write(captured)
+      }
+
+      childProcess.stdout?.on('data', (data: Buffer) => {
+        const chunk = captureChunk(data, stdoutDecoder, () => {
+          stdoutTruncated = true
+        })
+        stdout += chunk
+        stdoutBuffer += chunk
+
+        const lines = stdoutBuffer.split('\n')
+        stdoutBuffer = lines.pop() || ''
+
+        for (const line of lines) {
+          if (streamProcessor.processLine(line)) {
+            requestTermination()
+            break
+          }
+        }
+      })
+
+      childProcess.stderr?.on('data', (data: Buffer) => {
+        stderr += captureChunk(data, stderrDecoder, () => {
+          stderrTruncated = true
         })
       })
 
-      // Handle process errors
+      childProcess.on('close', (code: number | null, signal?: NodeJS.Signals | null) => {
+        void finish(code, signal)
+      })
+
       childProcess.on('error', (error: Error) => {
-        clearTimeout(executionTimeout)
-
-        // Get any result collected before error
-        const result = streamProcessor.getResult()
-
-        resolve({
-          stdout: result ? JSON.stringify(result) : stdout,
-          stderr: stderr || error.message,
-          exitCode: 1,
-          hasResult: result !== null,
-          resultJson: result !== null ? result : undefined,
-        })
+        processError = error
+        void finish(null)
       })
     })
+  }
+
+  private signalNumber(signal: NodeJS.Signals): number {
+    if (signal === 'SIGTERM') return 15
+    if (signal === 'SIGKILL') return 9
+    return 1
   }
 
   /**

--- a/src/execution/StreamProcessor.ts
+++ b/src/execution/StreamProcessor.ts
@@ -1,13 +1,14 @@
 /**
  * StreamProcessor - Simplified stream processing for agent output
  *
- * Handles cursor, claude, gemini, codex, and grok output in JSON format.
+ * Handles cursor, claude, gemini, codex, grok, and OpenCode output in JSON format.
  * - Cursor/Claude: Use --output-format json, return a single JSON with type: "result"
  * - Gemini: Uses --output-format stream-json, returns multiple JSON lines,
  *           assistant messages contain the response, type: "result" signals completion
  * - Codex: Uses --json flag with exec subcommand, returns stream of JSON events,
  *          agent_message items contain the response, turn.completed signals completion
  * - Grok: Uses --output-format json, returns a complete JSON object after exit
+ * - OpenCode: Uses --format json, returns step and text events as NDJSON
  */
 export class StreamProcessor {
   private resultJson: unknown = null
@@ -16,6 +17,8 @@ export class StreamProcessor {
   private isCodexFormat = false
   private codexAgentMessages: string[] = []
   private codexUsage: unknown = null
+  private isOpenCodeFormat = false
+  private openCodeResponseParts: string[] = []
 
   /**
    * Process a single line from the agent output stream.
@@ -55,6 +58,35 @@ export class StreamProcessor {
       if (json['type'] === 'thread.started') {
         this.isCodexFormat = true
         return false
+      }
+
+      const part = json['part']
+      if (
+        ['step_start', 'tool_use', 'text', 'step_finish'].includes(String(json['type'])) &&
+        this.isRecord(part)
+      ) {
+        this.isOpenCodeFormat = true
+      }
+
+      if (this.isOpenCodeFormat && json['type'] === 'text' && this.isRecord(part)) {
+        if (typeof part['text'] === 'string') {
+          this.openCodeResponseParts.push(part['text'])
+        }
+        return false
+      }
+
+      if (this.isOpenCodeFormat && json['type'] === 'step_finish' && this.isRecord(part)) {
+        const reason = part['reason']
+        if (reason === 'tool-calls' || reason === undefined || reason === null) {
+          return false
+        }
+        this.resultJson = {
+          type: 'result',
+          result: this.openCodeResponseParts.join(''),
+          status: reason === 'stop' ? 'success' : 'partial',
+          stop_reason: reason,
+        }
+        return true
       }
 
       // For Gemini: accumulate assistant message content
@@ -146,20 +178,28 @@ export class StreamProcessor {
 
     try {
       const json = JSON.parse(output.trim()) as unknown
-      if (!this.isRecord(json)) {
-        return false
+      if (this.isRecord(json)) {
+        const normalizedCompleteOutput = this.normalizeCompleteOutput(json)
+        if (normalizedCompleteOutput) {
+          this.resultJson = normalizedCompleteOutput
+          return true
+        }
       }
-
-      const normalizedCompleteOutput = this.normalizeCompleteOutput(json)
-      if (!normalizedCompleteOutput) {
-        return false
-      }
-
-      this.resultJson = normalizedCompleteOutput
-      return true
     } catch {
-      return false
+      // NDJSON streams are expected to fail whole-output JSON parsing.
     }
+
+    if (this.isOpenCodeFormat && this.openCodeResponseParts.length > 0) {
+      this.resultJson = {
+        type: 'result',
+        result: this.openCodeResponseParts.join(''),
+        status: 'partial',
+        stop_reason: 'process-exit',
+      }
+      return true
+    }
+
+    return false
   }
 
   private normalizeCompleteOutput(json: Record<string, unknown>): Record<string, unknown> | null {

--- a/src/execution/StreamProcessor.ts
+++ b/src/execution/StreamProcessor.ts
@@ -68,6 +68,12 @@ export class StreamProcessor {
         this.isOpenCodeFormat = true
       }
 
+      const normalizedError = this.normalizeFatalError(json)
+      if (normalizedError) {
+        this.resultJson = normalizedError
+        return true
+      }
+
       if (this.isOpenCodeFormat && json['type'] === 'text' && this.isRecord(part)) {
         if (typeof part['text'] === 'string') {
           this.openCodeResponseParts.push(part['text'])
@@ -179,6 +185,12 @@ export class StreamProcessor {
     try {
       const json = JSON.parse(output.trim()) as unknown
       if (this.isRecord(json)) {
+        const normalizedError = this.normalizeFatalError(json)
+        if (normalizedError) {
+          this.resultJson = normalizedError
+          return true
+        }
+
         const normalizedCompleteOutput = this.normalizeCompleteOutput(json)
         if (normalizedCompleteOutput) {
           this.resultJson = normalizedCompleteOutput
@@ -200,6 +212,54 @@ export class StreamProcessor {
     }
 
     return false
+  }
+
+  private normalizeFatalError(json: Record<string, unknown>): Record<string, unknown> | null {
+    const isFatalEvent =
+      json['type'] === 'error' ||
+      json['type'] === 'turn.failed' ||
+      (json['type'] === 'result' && json['status'] === 'error')
+
+    if (!isFatalEvent) {
+      return null
+    }
+
+    const error = this.isRecord(json['error']) ? json['error'] : undefined
+    const errorData = error && this.isRecord(error['data']) ? error['data'] : undefined
+    const message =
+      (typeof json['message'] === 'string' && json['message']) ||
+      (error && typeof error['message'] === 'string' && error['message']) ||
+      (errorData && typeof errorData['message'] === 'string' && errorData['message']) ||
+      (typeof json['error'] === 'string' && json['error']) ||
+      'Agent execution failed'
+    const errorType =
+      (error && typeof error['name'] === 'string' && error['name']) ||
+      (error && typeof error['type'] === 'string' && error['type'])
+    const errorRef =
+      (errorData && typeof errorData['ref'] === 'string' && errorData['ref']) ||
+      (error && typeof error['ref'] === 'string' && error['ref']) ||
+      (typeof json['ref'] === 'string' && json['ref'])
+    const sessionId =
+      (typeof json['sessionID'] === 'string' && json['sessionID']) ||
+      (typeof json['session_id'] === 'string' && json['session_id'])
+
+    const context: string[] = []
+    if (errorRef) context.push(`ref: ${errorRef}`)
+    if (sessionId) context.push(`sessionID: ${sessionId}`)
+    const formattedMessage = `${errorType ? `${errorType}: ` : ''}${message}${
+      context.length > 0 ? ` (${context.join(', ')})` : ''
+    }`
+
+    return {
+      type: 'result',
+      subtype: 'error',
+      is_error: true,
+      error: formattedMessage,
+      ...(errorType && { error_type: errorType }),
+      ...(errorRef && { error_ref: errorRef }),
+      ...(sessionId && { session_id: sessionId }),
+      ...(json['stats'] !== undefined && { stats: json['stats'] }),
+    }
   }
 
   private normalizeCompleteOutput(json: Record<string, unknown>): Record<string, unknown> | null {

--- a/src/execution/__tests__/AgentExecutor.test.ts
+++ b/src/execution/__tests__/AgentExecutor.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ExecutionParams } from '../../types/ExecutionParams.js'
 import {
@@ -22,6 +23,7 @@ import { spawn as mockSpawn } from 'node:child_process'
  */
 function createMockProcess(options: {
   stdoutData?: string
+  stdoutChunks?: Buffer[]
   stdoutDelay?: number
   stderrData?: string
   exitCode?: number
@@ -31,6 +33,7 @@ function createMockProcess(options: {
 }) {
   const {
     stdoutData,
+    stdoutChunks,
     stdoutDelay = 10,
     stderrData,
     exitCode = 0,
@@ -39,12 +42,17 @@ function createMockProcess(options: {
     triggerError,
   } = options
 
+  let closeCallback: ((code: number | null, signal?: NodeJS.Signals | null) => void) | undefined
+
   return {
     stdin: { end: vi.fn() },
     stdout: {
       on: vi.fn((event: string, callback: (data: Buffer) => void) => {
-        if (event === 'data' && stdoutData) {
-          setTimeout(() => callback(Buffer.from(stdoutData)), stdoutDelay)
+        if (event === 'data') {
+          const chunks = stdoutChunks ?? (stdoutData ? [Buffer.from(stdoutData)] : [])
+          chunks.forEach((chunk, index) => {
+            setTimeout(() => callback(chunk), stdoutDelay * (index + 1))
+          })
         }
       }),
     },
@@ -56,14 +64,22 @@ function createMockProcess(options: {
       }),
     },
     on: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
-      if (event === 'close' && !noClose) {
-        setTimeout(() => callback(exitCode), closeDelay)
+      if (event === 'close') {
+        closeCallback = callback
+        if (!noClose) {
+          setTimeout(() => callback(exitCode), closeDelay)
+        }
       }
       if (event === 'error' && triggerError) {
         setTimeout(() => callback(triggerError), stdoutDelay)
       }
     }),
-    kill: vi.fn(),
+    kill: vi.fn((signal?: NodeJS.Signals) => {
+      if (noClose && signal === 'SIGKILL') {
+        setTimeout(() => closeCallback?.(null, 'SIGKILL'), 0)
+      }
+      return true
+    }),
   } as any
 }
 
@@ -92,6 +108,7 @@ describe('AgentExecutor', () => {
 
       expect(config.agentType).toBe('cursor')
       expect(config.executionTimeout).toBe(DEFAULT_EXECUTION_TIMEOUT)
+      expect(config.maxOutputBytes).toBeGreaterThan(0)
     })
 
     it('should allow overriding execution timeout', () => {
@@ -108,6 +125,7 @@ describe('AgentExecutor', () => {
       const codexConfig = createExecutionConfig('codex')
       const glmConfig = createExecutionConfig('glm')
       const grokConfig = createExecutionConfig('grok')
+      const openCodeConfig = createExecutionConfig('opencode')
 
       expect(cursorConfig.agentType).toBe('cursor')
       expect(claudeConfig.agentType).toBe('claude')
@@ -115,6 +133,7 @@ describe('AgentExecutor', () => {
       expect(codexConfig.agentType).toBe('codex')
       expect(glmConfig.agentType).toBe('glm')
       expect(grokConfig.agentType).toBe('grok')
+      expect(openCodeConfig.agentType).toBe('opencode')
     })
 
     it('should allow setting agentsSettingsPath', () => {
@@ -187,6 +206,136 @@ describe('AgentExecutor', () => {
       await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
 
       expect(mockSpawn).toHaveBeenCalledWith('grok', expect.any(Array), expect.any(Object))
+    })
+
+    it('should use opencode run with non-interactive JSON output', async () => {
+      const executor = new AgentExecutor(createExecutionConfig('opencode'))
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'opencode',
+        expect.arrayContaining(['run', '--format', 'json', '--auto']),
+        expect.any(Object)
+      )
+    })
+  })
+
+  describe('global model and effort options', () => {
+    it('should pass AGENT_MODEL as --model', async () => {
+      const executor = new AgentExecutor(createExecutionConfig('codex', { model: 'gpt-5.6-luna' }))
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      expect(mockSpawn.mock.calls[0][1]).toEqual(
+        expect.arrayContaining(['--model', 'gpt-5.6-luna'])
+      )
+    })
+
+    it.each([
+      { agentType: 'codex', expected: ['-c', 'model_reasoning_effort="high"'] },
+      { agentType: 'claude', expected: ['--effort', 'high'] },
+      { agentType: 'glm', expected: ['--effort', 'high'] },
+      { agentType: 'grok', expected: ['--reasoning-effort', 'high'] },
+      { agentType: 'opencode', expected: ['--variant', 'high'] },
+    ] as const)('should map effort for $agentType', async ({ agentType, expected }) => {
+      const executor = new AgentExecutor(
+        createExecutionConfig(agentType, {
+          effort: 'high',
+          ...(agentType === 'glm' && { glmApiKey: 'zai-secret' }),
+        })
+      )
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      expect(mockSpawn.mock.calls[0][1]).toEqual(expect.arrayContaining(expected))
+    })
+
+    it.each([
+      'cursor',
+      'gemini',
+    ] as const)('should reject effort for %s when construction bypasses ServerConfig', async (agentType) => {
+      const executor = new AgentExecutor(createExecutionConfig(agentType, { effort: 'high' }))
+
+      const result = await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Test prompt',
+        cwd: '/tmp',
+      })
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toMatch(/AGENT_EFFORT is not supported/)
+      expect(mockSpawn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('OpenCode isolation and permissions', () => {
+    it.each([
+      { permission: 'read-only', edit: 'deny', externalDirectory: 'deny' },
+      { permission: 'safe-edit', edit: 'allow', externalDirectory: 'deny' },
+    ] as const)('should map $permission permissions without changing the global backend model', async ({
+      permission,
+      edit,
+      externalDirectory,
+    }) => {
+      const executor = new AgentExecutor(
+        createExecutionConfig('opencode', { permission, model: 'provider/model' })
+      )
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      const options = mockSpawn.mock.calls[0][2]
+      const permissionConfig = JSON.parse(options.env.OPENCODE_PERMISSION)
+      expect(permissionConfig.edit).toBe(edit)
+      expect(permissionConfig.external_directory).toBe(externalDirectory)
+      expect(mockSpawn.mock.calls[0][1]).toEqual(
+        expect.arrayContaining(['--model', 'provider/model'])
+      )
+    })
+
+    it('should isolate and clean OpenCode data and state directories per run', async () => {
+      const executor = new AgentExecutor(createExecutionConfig('opencode'))
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      const options = mockSpawn.mock.calls[0][2]
+      expect(options.env.XDG_DATA_HOME).toContain('subagent-opencode-')
+      expect(options.env.XDG_STATE_HOME).toContain('subagent-opencode-')
+      expect(fs.existsSync(options.env.XDG_DATA_HOME)).toBe(false)
+      expect(fs.existsSync(options.env.XDG_STATE_HOME)).toBe(false)
+    })
+
+    it('should copy existing OpenCode authentication into the isolated data home', async () => {
+      vi.stubEnv('XDG_DATA_HOME', '/user/data')
+      const copySpy = vi.spyOn(fs.promises, 'copyFile').mockResolvedValue()
+      const executor = new AgentExecutor(createExecutionConfig('opencode'))
+
+      await executor.executeAgent({ agent: 'test-agent', prompt: 'Test prompt', cwd: '/tmp' })
+
+      expect(copySpy).toHaveBeenCalledWith(
+        '/user/data/opencode/auth.json',
+        expect.stringMatching(/subagent-opencode-.*\/data\/opencode\/auth\.json$/)
+      )
+    })
+
+    it('should warn and continue when OpenCode authentication cannot be copied', async () => {
+      const copyError = Object.assign(new Error('Permission denied'), { code: 'EACCES' })
+      vi.spyOn(fs.promises, 'copyFile').mockRejectedValue(copyError)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const executor = new AgentExecutor(createExecutionConfig('opencode'))
+
+      const result = await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Test prompt',
+        cwd: '/tmp',
+      })
+
+      expect(result.exitCode).toBe(0)
+      expect(
+        consoleSpy.mock.calls.some(([message]) =>
+          String(message).includes('Could not copy OpenCode authentication')
+        )
+      ).toBe(true)
     })
   })
 
@@ -636,6 +785,29 @@ describe('AgentExecutor', () => {
         request_id: 'request-123',
       })
     })
+
+    it('should return partial OpenCode text when the finish event is missing', async () => {
+      mockSpawn.mockImplementationOnce(() =>
+        createMockProcess({
+          stdoutData: '{"type":"text","part":{"text":"partial answer"}}',
+        })
+      )
+      const executor = new AgentExecutor(createExecutionConfig('opencode'))
+
+      const result = await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Test prompt',
+        cwd: '/tmp',
+      })
+
+      expect(result.hasResult).toBe(true)
+      expect(result.resultJson).toEqual({
+        type: 'result',
+        result: 'partial answer',
+        status: 'partial',
+        stop_reason: 'process-exit',
+      })
+    })
   })
 
   describe('execution performance monitoring', () => {
@@ -888,6 +1060,27 @@ describe('AgentExecutor', () => {
       expect(result.resultJson).toBeDefined()
     })
 
+    it('should preserve a result when SIGTERM escalates to SIGKILL', async () => {
+      mockSpawn.mockImplementationOnce(() =>
+        createMockProcess({
+          stdoutData: '{"type": "result", "data": "Success"}\n',
+          noClose: true,
+        })
+      )
+      const executor = new AgentExecutor(
+        createExecutionConfig('cursor', { executionTimeout: 5000 })
+      )
+
+      const result = await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Stream JSON data',
+        cwd: '/tmp',
+      })
+
+      expect(result.exitCode).toBe(137)
+      expect(result.hasResult).toBe(true)
+    })
+
     it('should distinguish timeout with partial result from complete timeout', async () => {
       mockSpawn.mockImplementationOnce(() =>
         createMockProcess({
@@ -908,6 +1101,77 @@ describe('AgentExecutor', () => {
       expect(result.exitCode).toBe(124)
       expect(result.hasResult).toBe(true)
       expect(result.resultJson).toEqual({ type: 'result', partial: true })
+    })
+  })
+
+  describe('process resource limits', () => {
+    it('should stop and report an error when combined output exceeds the capture limit', async () => {
+      mockSpawn.mockImplementationOnce(() =>
+        createMockProcess({
+          stdoutData: 'output larger than the configured limit',
+        })
+      )
+      const executor = new AgentExecutor(createExecutionConfig('cursor', { maxOutputBytes: 8 }))
+
+      const result = await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Produce output',
+        cwd: '/tmp',
+      })
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain('exceeded 8 bytes')
+      expect(result.stdout).toBe('output l')
+      expect(mockSpawn.mock.results[0]?.value.kill).toHaveBeenCalledWith('SIGTERM')
+    })
+
+    it('should decode UTF-8 characters split across stdout chunks', async () => {
+      const output = Buffer.from('{"type":"result","data":"日本語"}\n')
+      const splitAt = output.indexOf(Buffer.from('日')) + 1
+      mockSpawn.mockImplementationOnce(() =>
+        createMockProcess({
+          stdoutChunks: [output.subarray(0, splitAt), output.subarray(splitAt)],
+        })
+      )
+      const executor = new AgentExecutor(createExecutionConfig('cursor'))
+
+      const result = await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Produce output',
+        cwd: '/tmp',
+      })
+
+      expect(result.resultJson).toEqual({ type: 'result', data: '日本語' })
+    })
+
+    it('should not emit a replacement character when the byte cap splits UTF-8', async () => {
+      mockSpawn.mockImplementationOnce(() => createMockProcess({ stdoutData: 'abc日' }))
+      const executor = new AgentExecutor(createExecutionConfig('cursor', { maxOutputBytes: 4 }))
+
+      const result = await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Produce output',
+        cwd: '/tmp',
+      })
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stdout).toBe('abc')
+      expect(result.stdout).not.toContain('�')
+    })
+
+    it('should return exit code 127 when the CLI cannot be spawned', async () => {
+      const unavailable = Object.assign(new Error('spawn cursor-agent ENOENT'), { code: 'ENOENT' })
+      mockSpawn.mockImplementationOnce(() => createMockProcess({ triggerError: unavailable }))
+      const executor = new AgentExecutor(createExecutionConfig('cursor'))
+
+      const result = await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Run',
+        cwd: '/tmp',
+      })
+
+      expect(result.exitCode).toBe(127)
+      expect(result.stderr).toContain('ENOENT')
     })
   })
 })

--- a/src/execution/__tests__/AgentExecutor.test.ts
+++ b/src/execution/__tests__/AgentExecutor.test.ts
@@ -808,6 +808,35 @@ describe('AgentExecutor', () => {
         stop_reason: 'process-exit',
       })
     })
+
+    it('should return a structured result for OpenCode error events', async () => {
+      mockSpawn.mockImplementationOnce(() =>
+        createMockProcess({
+          stdoutData:
+            '{"type":"error","sessionID":"session-123","error":{"name":"UnknownError","data":{"message":"Provider failed","ref":"error-ref"}}}\n',
+          exitCode: 1,
+        })
+      )
+      const executor = new AgentExecutor(createExecutionConfig('opencode'))
+
+      const result = await executor.executeAgent({
+        agent: 'test-agent',
+        prompt: 'Test prompt',
+        cwd: '/tmp',
+      })
+
+      expect(result.exitCode).toBe(1)
+      expect(result.hasResult).toBe(true)
+      expect(result.resultJson).toEqual({
+        type: 'result',
+        subtype: 'error',
+        is_error: true,
+        error: 'UnknownError: Provider failed (ref: error-ref, sessionID: session-123)',
+        error_type: 'UnknownError',
+        error_ref: 'error-ref',
+        session_id: 'session-123',
+      })
+    })
   })
 
   describe('execution performance monitoring', () => {

--- a/src/execution/__tests__/StreamProcessor.test.ts
+++ b/src/execution/__tests__/StreamProcessor.test.ts
@@ -211,6 +211,88 @@ describe('StreamProcessor', () => {
       })
     })
 
+    it('should normalize OpenCode error events with diagnostic context', () => {
+      const openCodeError =
+        '{"type":"error","timestamp":1784020603139,"sessionID":"ses_0a015ef55ffePMBqnSUUKOWwRG","error":{"name":"UnknownError","data":{"message":"Unexpected server error. Check server logs for details.","ref":"err_c481aeec"}}}'
+
+      expect(processor.processLine(openCodeError)).toBe(true)
+      expect(processor.getResult()).toEqual({
+        type: 'result',
+        subtype: 'error',
+        is_error: true,
+        error:
+          'UnknownError: Unexpected server error. Check server logs for details. (ref: err_c481aeec, sessionID: ses_0a015ef55ffePMBqnSUUKOWwRG)',
+        error_type: 'UnknownError',
+        error_ref: 'err_c481aeec',
+        session_id: 'ses_0a015ef55ffePMBqnSUUKOWwRG',
+      })
+    })
+
+    it('should normalize Codex turn.failed events', () => {
+      expect(
+        processor.processLine(
+          '{"type":"turn.failed","error":{"message":"The model is unavailable"}}'
+        )
+      ).toBe(true)
+      expect(processor.getResult()).toEqual({
+        type: 'result',
+        subtype: 'error',
+        is_error: true,
+        error: 'The model is unavailable',
+      })
+    })
+
+    it('should normalize top-level Codex and Grok error events', () => {
+      expect(processor.processLine('{"type":"error","message":"Unknown model id"}')).toBe(true)
+      expect(processor.getResult()).toEqual({
+        type: 'result',
+        subtype: 'error',
+        is_error: true,
+        error: 'Unknown model id',
+      })
+    })
+
+    it('should normalize Gemini result errors', () => {
+      expect(
+        processor.processLine(
+          '{"type":"result","status":"error","error":{"type":"unknown","message":"Model not found"},"stats":{"total_tokens":0}}'
+        )
+      ).toBe(true)
+      expect(processor.getResult()).toEqual({
+        type: 'result',
+        subtype: 'error',
+        is_error: true,
+        error: 'unknown: Model not found',
+        error_type: 'unknown',
+        stats: { total_tokens: 0 },
+      })
+    })
+
+    it('should ignore non-fatal Codex error items and allow the turn to complete', () => {
+      expect(processor.processLine('{"type":"thread.started","thread_id":"thread-1"}')).toBe(false)
+      expect(
+        processor.processLine(
+          '{"type":"item.completed","item":{"id":"item-1","type":"error","message":"stream lagged"}}'
+        )
+      ).toBe(false)
+      expect(
+        processor.processLine(
+          '{"type":"item.completed","item":{"id":"item-2","type":"agent_message","text":"Done"}}'
+        )
+      ).toBe(false)
+      expect(
+        processor.processLine(
+          '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+        )
+      ).toBe(true)
+      expect(processor.getResult()).toEqual({
+        type: 'result',
+        result: 'Done',
+        usage: { input_tokens: 1, output_tokens: 1 },
+        status: 'success',
+      })
+    })
+
     it('should concatenate multiple agent_messages with newlines', () => {
       // Given: Codex output with multiple agent_message items
       const codexOutputStream = [

--- a/src/execution/__tests__/StreamProcessor.test.ts
+++ b/src/execution/__tests__/StreamProcessor.test.ts
@@ -166,6 +166,51 @@ describe('StreamProcessor', () => {
       })
     })
 
+    it('should collect OpenCode text across tool steps until stop', () => {
+      expect(processor.processLine('{"type":"step_start","part":{}}')).toBe(false)
+      expect(processor.processLine('{"type":"text","part":{"text":"part 1"}}')).toBe(false)
+      expect(processor.processLine('{"type":"step_finish","part":{"reason":"tool-calls"}}')).toBe(
+        false
+      )
+      expect(processor.processLine('{"type":"text","part":{"text":"part 2"}}')).toBe(false)
+      expect(processor.processLine('{"type":"step_finish","part":{"reason":"stop"}}')).toBe(true)
+
+      expect(processor.getResult()).toEqual({
+        type: 'result',
+        result: 'part 1part 2',
+        status: 'success',
+        stop_reason: 'stop',
+      })
+    })
+
+    it('should mark a non-stop OpenCode finish as partial', () => {
+      expect(processor.processLine('{"type":"text","part":{"text":"truncated"}}')).toBe(false)
+      expect(processor.processLine('{"type":"step_finish","part":{"reason":"length"}}')).toBe(true)
+
+      expect(processor.getResult()).toEqual({
+        type: 'result',
+        result: 'truncated',
+        status: 'partial',
+        stop_reason: 'length',
+      })
+    })
+
+    it('should preserve OpenCode text as partial when the process exits without a finish event', () => {
+      expect(processor.processLine('{"type":"text","part":{"text":"work in progress"}}')).toBe(
+        false
+      )
+
+      expect(
+        processor.processCompleteOutput('{"type":"text","part":{"text":"work in progress"}}\n')
+      ).toBe(true)
+      expect(processor.getResult()).toEqual({
+        type: 'result',
+        result: 'work in progress',
+        status: 'partial',
+        stop_reason: 'process-exit',
+      })
+    })
+
     it('should concatenate multiple agent_messages with newlines', () => {
       // Given: Codex output with multiple agent_message items
       const codexOutputStream = [

--- a/src/server/McpServer.ts
+++ b/src/server/McpServer.ts
@@ -76,6 +76,8 @@ export class McpServer {
     const executionConfig = createExecutionConfig(config.agentType, {
       executionTimeout: config.executionTimeoutMs,
       permission: config.agentPermission,
+      ...(config.agentModel && { model: config.agentModel }),
+      ...(config.agentEffort && { effort: config.agentEffort }),
       ...(config.agentsSettingsPath && { agentsSettingsPath: config.agentsSettingsPath }),
       ...(config.cursorApiKey && { cursorApiKey: config.cursorApiKey }),
       ...(config.glmApiKey && { glmApiKey: config.glmApiKey }),

--- a/src/tools/RunAgentTool.ts
+++ b/src/tools/RunAgentTool.ts
@@ -579,7 +579,14 @@ export class RunAgentTool {
     // Priority 2: Check process exit code (excluding special cases)
     // 143: SIGTERM (normal termination)
     // 124: Timeout (may have partial result)
-    return exitCode !== 0 && exitCode !== 143 && exitCode !== 124
+    // 137: SIGKILL after a complete result when the CLI ignores our SIGTERM
+    const hasStructuredResult = resultJson !== null && resultJson !== undefined
+    return (
+      exitCode !== 0 &&
+      exitCode !== 143 &&
+      exitCode !== 124 &&
+      !(exitCode === 137 && hasStructuredResult)
+    )
   }
 
   private isPartialResult(resultJson: unknown): boolean {
@@ -625,7 +632,9 @@ export class RunAgentTool {
 
     const isSuccess =
       (!isPartialSuccess && result.exitCode === 0) || // Normal completion
-      (!isPartialSuccess && result.exitCode === 143 && result.hasResult === true) // SIGTERM with result
+      (!isPartialSuccess &&
+        (result.exitCode === 143 || result.exitCode === 137) &&
+        result.hasResult === true) // Terminated after receiving a result
 
     // Build response data structure (ADR-0003)
     // This object is used in both content[0].text and structuredContent


### PR DESCRIPTION
## Summary

- Add OpenCode as a selectable `AGENT_TYPE` with per-run data/state isolation and native permission mapping.
- Add server-wide `AGENT_MODEL` and `AGENT_EFFORT` settings with backend-specific flags and validation.
- Harden subprocess execution with bounded output capture, UTF-8-safe streaming, TERM-to-KILL escalation, missing-CLI handling, and partial-result recovery.
- Make agent discovery deterministic and symlink-safe while preserving alias names.
- Document backend behavior and update the package metadata for v0.11.0.

## Permission behavior

OpenCode keeps its standard tool behavior. Built-in edit, shell, subagent, and external-directory operations are restricted by `AGENT_PERMISSION`; custom and MCP tools continue to follow the user-provided OpenCode permission configuration.

## Validation

- `npm run check:all`
- 19 test files passed
- 368 tests passed