### PR TITLE
Fix server description length validation

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shinpr/sub-agents-mcp",
-  "description": "MCP server for AI sub-agent delegation across Cursor, Claude, Codex, Gemini, GLM, Kimi, Grok, and OpenCode",
+  "description": "AI sub-agent delegation for Cursor, Claude, Codex, Gemini, GLM, Kimi, Grok, and OpenCode",
   "vendor": "Shinsuke Kagawa",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- shorten the server description to satisfy the 100-character registry limit
- retain the complete list of supported AI tools

## Testing

- validated that server.json parses successfully
- confirmed the description is 88 characters
- ran npm run check:all (390 tests passed)